### PR TITLE
Add CODEOWNERS for PR review

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# At least one of the code owners below will be required on each PR:
+
+* @smmatte @rectified95 @rachel-slater @jackbk @turalf @markAtMicrosoft @matthidinger


### PR DESCRIPTION
We will use this file to require a coach, sponsor or garage LT to review along with at least one intern each PR