### PR TITLE
Fix mongo schema to work with update models

### DIFF
--- a/private-templates-service/adaptivecards-templating-service/src/models/models.ts
+++ b/private-templates-service/adaptivecards-templating-service/src/models/models.ts
@@ -23,7 +23,7 @@ export interface ITemplateInstance {
 export interface ITemplate {
   _id?: string;
   instances: ITemplateInstance[];
-  tags: string[];
+  tags?: string[];
   owner?: string;
   createdAt?: Date;
   updatedAt?: Date;

--- a/private-templates-service/adaptivecards-templating-service/src/models/mongo/TemplateModel.ts
+++ b/private-templates-service/adaptivecards-templating-service/src/models/mongo/TemplateModel.ts
@@ -22,10 +22,10 @@ export const TemplateInstanceSchema: Schema = new Schema(
 export const TemplateSchema: Schema = new Schema(
   {
     _id: { type: String, default: mongoose.Types.ObjectId() },
-    instances: { type: [TemplateInstanceSchema], required: true, default: [TemplateInstanceSchema] },
-    tags: { type: [String], default: [String] },
-    owner: { type: String, required: true }, // todo: add ref: "User" so it checks if owner exists and make type ObjectID
-    isPublished: { type: String, required: true }
+    instances: { type: [TemplateInstanceSchema], required: true, default: [] },
+    tags: { type: [String], default: [] },
+    owner: { type: String, default: "" }, // todo: add ref: "User" so it checks if owner exists and make type ObjectID
+    isPublished: { type: String, default: false }
   },
   {
     versionKey: false,

--- a/private-templates-service/adaptivecards-templating-service/src/models/mongo/UserModel.ts
+++ b/private-templates-service/adaptivecards-templating-service/src/models/mongo/UserModel.ts
@@ -15,9 +15,10 @@ export interface IUserModel extends mongoose.Document, IUser {
 export const UserSchema: Schema = new Schema(
   {
     _id: { type: String, default: mongoose.Types.ObjectId() },
-    team: { type: [String], default: [String] },
-    org: { type: [String], default: [String] },
-    email: { type: String, required: true, default: "" }
+    authId: { type: String, required: true },
+    issuer: { type: String, required: true },
+    team: { type: [String], default: [] },
+    org: { type: [String], default: [] }
   },
   {
     versionKey: false,

--- a/private-templates-service/adaptivecards-templating-service/src/storageproviders/InMemoryDBProvider.ts
+++ b/private-templates-service/adaptivecards-templating-service/src/storageproviders/InMemoryDBProvider.ts
@@ -191,7 +191,7 @@ export class InMemoryDBProvider implements StorageProvider {
       (query.owner && !(query.owner === template.owner)) ||
       (query._id && !(query._id === template._id)) ||
       (query.isPublished && !(query.isPublished === template.isPublished)) ||
-      (query.tags && !this._ifContainsList(template.tags, query.tags))
+      (query.tags && template.tags && !this._ifContainsList(template.tags, query.tags))
     ) {
       return false;
     }


### PR DESCRIPTION
Update MongoSchema to work with updated by Grace data models:
1) **IUser**: **authId and issuer fields** were added. **Email field** was removed
2) **Tags** field for ITemplate is now optional.

I have also modified **matchTemplate** function of **InMemoryStorageProvider** to correctly query based on the data models changes.