### PR TITLE
Display Profile Picture + Move Microsoft Graph into Redux

### DIFF
--- a/private-templates-service/client/src/App.tsx
+++ b/private-templates-service/client/src/App.tsx
@@ -194,7 +194,8 @@ class App extends Component<Props, State> {
         this.props.userLogin({
           displayName: user.displayName,
           email: user.mail || user.userPrincipalName,
-          organization: org
+          organization: org,
+          avatarURL: user.image,
         });
       }
     } catch (err) {

--- a/private-templates-service/client/src/Services/GraphService.ts
+++ b/private-templates-service/client/src/Services/GraphService.ts
@@ -3,7 +3,7 @@ import { Client, AuthProviderCallback } from '@microsoft/microsoft-graph-client'
 import { AuthResponse } from 'msal';
 // var graph = require("@microsoft/microsoft-graph-client");
 
-function getAuthenticatedClient(accessToken: AuthResponse): Client {
+export function getAuthenticatedClient(accessToken: AuthResponse): Client {
   // Initialize Graph client
   const client = Client.init({
     // Use the provided access token to authenticate
@@ -14,19 +14,4 @@ function getAuthenticatedClient(accessToken: AuthResponse): Client {
   });
 
   return client;
-}
-
-// TODO: Refactor into a class, store this in state to eliminate unneccesary retrievals
-export async function getUserDetails(accessToken: AuthResponse) {
-  const client = getAuthenticatedClient(accessToken);
-  const user = await client.api("/me").get();
-  const image = await client.api("/me/photos/240x240/$value").get();
-  user.image = URL.createObjectURL(image);
-  return user;
-}
-
-export async function getOrgDetails(accessToken: AuthResponse) {
-  const client = getAuthenticatedClient(accessToken);
-  const org = await client.api("/organization").get();
-  return org;
 }

--- a/private-templates-service/client/src/Services/GraphService.ts
+++ b/private-templates-service/client/src/Services/GraphService.ts
@@ -20,6 +20,8 @@ function getAuthenticatedClient(accessToken: AuthResponse): Client {
 export async function getUserDetails(accessToken: AuthResponse) {
   const client = getAuthenticatedClient(accessToken);
   const user = await client.api("/me").get();
+  const image = await client.api("/me/photos/240x240/$value").get();
+  user.image = URL.createObjectURL(image);
   return user;
 }
 

--- a/private-templates-service/client/src/components/SideBar/SideBar.tsx
+++ b/private-templates-service/client/src/components/SideBar/SideBar.tsx
@@ -7,7 +7,7 @@ import { RootState } from '../../store/rootReducer';
 import { UserType } from '../../store/auth/types';
 import { newTemplate } from '../../store/currentTemplate/actions';
 
-import { UserAvatar } from './UserAvatar';
+import UserAvatar from './UserAvatar';
 import mainLogo from '../../assets/adaptive-cards-100-logo.png';
 
 // CSS

--- a/private-templates-service/client/src/components/SideBar/UserAvatar.tsx
+++ b/private-templates-service/client/src/components/SideBar/UserAvatar.tsx
@@ -18,10 +18,10 @@ const mapStateToProps = (state: RootState) => {
 class UserAvatar extends React.Component<Props> {
   // If a user avatar is available, return an img tag with the pic
   render() {
-    if (this.props.user && this.props.user.avatarURL) {
+    if (this.props.user && this.props.user.imageURL) {
       return (
         <AvatarIcon
-          src={this.props.user.avatarURL}
+          src={this.props.user.imageURL}
           alt="user"
           className="rounded-circle align-self-center"
         ></AvatarIcon>

--- a/private-templates-service/client/src/components/SideBar/UserAvatar.tsx
+++ b/private-templates-service/client/src/components/SideBar/UserAvatar.tsx
@@ -4,7 +4,7 @@ import { RootState } from "../../store/rootReducer";
 import { UserType } from "../../store/auth/types";
 import { AvatarIcon, DefaultAvatarIcon } from "./styled";
 
-interface UserAvatarProps {
+interface Props {
   user?: UserType;
   iconSize?: string;
 }
@@ -15,21 +15,23 @@ const mapStateToProps = (state: RootState) => {
   };
 };
 
-export function UserAvatar(props: UserAvatarProps): ReactElement {
+class UserAvatar extends React.Component<Props> {
   // If a user avatar is available, return an img tag with the pic
-  if (props.user && props.user.avatar) {
+  render() {
+    if (this.props.user && this.props.user.avatarURL) {
+      return (
+        <AvatarIcon
+          src={this.props.user.avatarURL}
+          alt="user"
+          className="rounded-circle align-self-center"
+        ></AvatarIcon>
+      );
+    }
+    // No avatar available, return a default icon
     return (
-      <AvatarIcon
-        src={props.user.avatar}
-        alt="user"
-        className="rounded-circle align-self-center"
-      ></AvatarIcon>
+      <DefaultAvatarIcon iconName="contact" size={this.props.iconSize} ></DefaultAvatarIcon>
     );
   }
-  // No avatar available, return a default icon
-  return (
-    <DefaultAvatarIcon iconName="contact" size={props.iconSize} ></DefaultAvatarIcon>
-  );
 }
 
 export default connect(mapStateToProps)(UserAvatar);

--- a/private-templates-service/client/src/components/SideBar/styled.tsx
+++ b/private-templates-service/client/src/components/SideBar/styled.tsx
@@ -56,11 +56,12 @@ export const LogoTextSubHeader = styled.div`
 export const UserWrapper = styled.div`
   display: flex;
   flex-direction: column;
-  margin: 48px 0;
+  margin: 60px 0;
 `
 
 export const AvatarIcon = styled.img`
-  width: 32px;
+  width: 80px;
+  margin-bottom: 16px;
 `;
 
 export const DefaultAvatarIcon = styled(Icon) <{ size?: string }>`

--- a/private-templates-service/client/src/store/auth/actions.ts
+++ b/private-templates-service/client/src/store/auth/actions.ts
@@ -1,4 +1,13 @@
-import { LOGIN, LOGOUT, UserType, AuthAction } from './types';
+import {
+  LOGIN,
+  LOGOUT,
+  LOGIN_POPUP_BEGIN,
+  LOGIN_POPUP_FAIL,
+  LOGIN_POPUP_SUCCESS,
+  UserType,
+  AuthAction,
+  LoginPopupAction
+} from './types';
 
 export function login(user: UserType): AuthAction {
   return {
@@ -12,5 +21,32 @@ export function logout(): AuthAction {
   return {
     type: LOGOUT,
     text: 'User logout'
+  }
+}
+
+export function loginPopupBegin(): LoginPopupAction {
+  return {
+    type: LOGIN_POPUP_BEGIN
+  }
+}
+
+export function loginPopupFail(): LoginPopupAction {
+  return {
+    type: LOGIN_POPUP_FAIL
+  }
+}
+
+export function loginPopupSucess(): LoginPopupAction {
+  return {
+    type: LOGIN_POPUP_SUCCESS
+  }
+}
+
+export function loginPopup(): (dispatch: any) => void {
+
+  return function (dispatch: any) {
+    dispatch(loginPopupBegin());
+
+
   }
 }

--- a/private-templates-service/client/src/store/auth/reducers.ts
+++ b/private-templates-service/client/src/store/auth/reducers.ts
@@ -1,29 +1,94 @@
 import {
   AuthState,
   AuthAction,
-  LOGIN,
+  UserType,
+  AccessTokenAction,
+  GetUserDetailsAction,
+  GetOrgDetailsAction,
+  GetProfilePictureAction,
   LOGOUT,
+  ACCESS_TOKEN_SET,
+  GET_USER_DETAILS,
+  GET_USER_DETAILS_FAILURE,
+  GET_USER_DETAILS_SUCCESS,
+  GET_ORG_DETAILS,
+  GET_ORG_DETAILS_FAILURE,
+  GET_ORG_DETAILS_SUCCESS,
+  GET_PROFILE_PICTURE,
+  GET_PROFILE_PICTURE_FAILURE,
+  GET_PROFILE_PICTURE_SUCCESS,
 } from './types';
 
 const initialState: AuthState = {
   isAuthenticated: false,
   user: undefined,
+  isFetching: false,
+  accessToken: undefined,
 }
 
-export function authReducer(state = initialState, action: AuthAction): AuthState {
+const initialUserState: UserType = {
+  displayName: "",
+  email: "",
+}
+
+function user(user = initialUserState, action: AuthAction | AccessTokenAction | GetUserDetailsAction | GetOrgDetailsAction | GetProfilePictureAction): UserType | undefined {
   switch (action.type) {
-    case LOGIN:
+    case GET_USER_DETAILS_SUCCESS:
+      return {
+        ...user,
+        ...action.user
+      }
+    case GET_ORG_DETAILS_SUCCESS:
+      return {
+        ...user,
+        organization: action.org
+      }
+    case GET_PROFILE_PICTURE_SUCCESS:
+      return {
+        ...user,
+        imageURL: action.imageURL,
+      }
+    default:
+      return user;
+  }
+}
+
+export function authReducer(state = initialState, action: AuthAction | AccessTokenAction | GetUserDetailsAction | GetOrgDetailsAction | GetProfilePictureAction): AuthState {
+  switch (action.type) {
+    case GET_USER_DETAILS:
+    case GET_ORG_DETAILS:
+    case GET_PROFILE_PICTURE:
+      return {
+        ...state,
+        isFetching: true,
+      };
+    case GET_USER_DETAILS_FAILURE:
+    case GET_ORG_DETAILS_FAILURE:
+    case GET_PROFILE_PICTURE_FAILURE:
+      return {
+        ...state,
+        isFetching: false,
+      }
+    case GET_USER_DETAILS_SUCCESS:
+    case GET_ORG_DETAILS_SUCCESS:
+    case GET_PROFILE_PICTURE_SUCCESS:
+      return {
+        ...state,
+        user: user(state.user, action),
+      }
+    case ACCESS_TOKEN_SET:
       return {
         ...state,
         isAuthenticated: true,
-        user: action.user
+        accessToken: action.accessToken,
       }
-
     case LOGOUT:
       return {
         ...state,
         isAuthenticated: false,
-        user: undefined
+        user: undefined,
+        accessToken: undefined,
+        isFetching: false,
       }
     default:
       return state;

--- a/private-templates-service/client/src/store/auth/types.ts
+++ b/private-templates-service/client/src/store/auth/types.ts
@@ -1,16 +1,34 @@
+import { AuthResponse } from "msal";
+
 export interface AuthState {
   isAuthenticated: boolean;
   user?: UserType;
+  isFetching: boolean;
+  accessToken?: AuthResponse;
 }
 
 export interface UserType {
   displayName: string;
   email: string;
   organization?: string;
-  avatarURL?: string;
+  imageURL?: string;
 }
 
 // Action Types
+export const ACCESS_TOKEN_SET = 'ACCESS_TOKEN_SET';
+
+export const GET_USER_DETAILS = 'GET_USER_DETAILS';
+export const GET_USER_DETAILS_SUCCESS = 'GET_USER_DETAILS_SUCCESS';
+export const GET_USER_DETAILS_FAILURE = 'GET_USER_DETAILS_FAILURE';
+
+export const GET_ORG_DETAILS = 'GET_ORG_DETAILS';
+export const GET_ORG_DETAILS_SUCCESS = 'GET_ORG_DETAILS_SUCCESS';
+export const GET_ORG_DETAILS_FAILURE = 'GET_ORG_DETAILS_FAILURE';
+
+export const GET_PROFILE_PICTURE = 'GET_PROFILE_PICTURE';
+export const GET_PROFILE_PICTURE_SUCCESS = 'GET_PROFILE_PICTURE_SUCCESS';
+export const GET_PROFILE_PICTURE_FAILURE = 'GET_PROFILE_PICTURE_FAILURE';
+
 export const LOGIN = 'LOGIN';
 export const LOGOUT = 'LOGOUT';
 
@@ -20,11 +38,27 @@ export const LOGIN_POPUP_SUCCESS = 'LOGIN_POPUP_SUCCESS';
 
 // Actions
 export interface AuthAction {
-  type: typeof LOGIN | typeof LOGOUT;
+  type: typeof LOGOUT;
   text: string;
   user?: UserType;
 }
 
-export interface LoginPopupAction {
-  type: typeof LOGIN_POPUP_BEGIN | typeof LOGIN_POPUP_FAIL | typeof LOGIN_POPUP_SUCCESS;
+export interface GetUserDetailsAction {
+  type: typeof GET_USER_DETAILS | typeof GET_USER_DETAILS_SUCCESS | typeof GET_USER_DETAILS_FAILURE;
+  user?: UserType;
+}
+
+export interface GetOrgDetailsAction {
+  type: typeof GET_ORG_DETAILS | typeof GET_ORG_DETAILS_SUCCESS | typeof GET_ORG_DETAILS_FAILURE;
+  org?: string;
+}
+
+export interface GetProfilePictureAction {
+  type: typeof GET_PROFILE_PICTURE | typeof GET_PROFILE_PICTURE_SUCCESS | typeof GET_PROFILE_PICTURE_FAILURE;
+  imageURL?: string;
+}
+
+export interface AccessTokenAction {
+  type: typeof ACCESS_TOKEN_SET;
+  accessToken: AuthResponse;
 }

--- a/private-templates-service/client/src/store/auth/types.ts
+++ b/private-templates-service/client/src/store/auth/types.ts
@@ -14,9 +14,17 @@ export interface UserType {
 export const LOGIN = 'LOGIN';
 export const LOGOUT = 'LOGOUT';
 
+export const LOGIN_POPUP_BEGIN = 'LOGIN_POPUP_BEGIN';
+export const LOGIN_POPUP_FAIL = 'LOGIN_POPUP_FAIL';
+export const LOGIN_POPUP_SUCCESS = 'LOGIN_POPUP_SUCCESS';
+
 // Actions
 export interface AuthAction {
   type: typeof LOGIN | typeof LOGOUT;
   text: string;
   user?: UserType;
+}
+
+export interface LoginPopupAction {
+  type: typeof LOGIN_POPUP_BEGIN | typeof LOGIN_POPUP_FAIL | typeof LOGIN_POPUP_SUCCESS;
 }

--- a/private-templates-service/client/src/store/auth/types.ts
+++ b/private-templates-service/client/src/store/auth/types.ts
@@ -7,7 +7,7 @@ export interface UserType {
   displayName: string;
   email: string;
   organization?: string;
-  avatar?: string;
+  avatarURL?: string;
 }
 
 // Action Types


### PR DESCRIPTION
## Description
This pr adds profile pictures associated with microsoft account. It also moves the other api calls to microsoft graph into redux, and saves the access token into the store.
[AB#33705](https://microsoftgarage.visualstudio.com/002806e2-ebaa-4672-9d2e-5fe5d29154ef/_workitems/edit/33705)


## Screenshots
No profile picture:
![image](https://user-images.githubusercontent.com/19780117/74971516-17c2c000-53d5-11ea-9030-fe46185d9d8c.png)

Profile picture:
![image](https://user-images.githubusercontent.com/19780117/74972574-d59a7e00-53d6-11ea-8efd-2de85e71d344.png)
