### PR TITLE
Add additional appID

### DIFF
--- a/private-templates-service/client/src/Config.tsx
+++ b/private-templates-service/client/src/Config.tsx
@@ -1,7 +1,11 @@
 import { } from "react"; // Typescripte requires every file to have an import
 
 export default {
-  appId: "4803f66a-136d-4155-a51e-6d98400d5506",
+  appId: process.env.NODE_ENV === 'development' ?
+    "cc02a0f4-ef1b-4513-a431-9aca7b2f7fca" :
+    (process.env.REACT_APP_HOST_ENV === 'dev' ?
+      "4803f66a-136d-4155-a51e-6d98400d5506" :
+      "ed0125aa-a0c3-48d5-8e2f-cd05d858e7ef"),
   redirectUri: process.env.NODE_ENV === 'development' ?
     "http://localhost:3000" :
     (process.env.REACT_APP_HOST_ENV === 'dev' ?


### PR DESCRIPTION
[AB#33794](https://microsoftgarage.visualstudio.com/002806e2-ebaa-4672-9d2e-5fe5d29154ef/_workitems/edit/33794)
Separate app-registration IDs should fix the bug where users cannot log in because they are already logged-in in another url. 