### PR TITLE
Fix json encoding

### DIFF
--- a/private-templates-service/adaptivecards-templating-service/src/TemplateServiceClient.ts
+++ b/private-templates-service/adaptivecards-templating-service/src/TemplateServiceClient.ts
@@ -6,7 +6,7 @@ import { TemplateError, ApiError, ServiceErrorMessage } from "./models/errorMode
 import { StorageProvider } from ".";
 import { ITemplate, JSONResponse, ITemplateInstance, IUser } from ".";
 import { SortBy, SortOrder, TemplatePreview, TemplateState, TemplateInstancePreview, UserPreview, TagList } from "./models/models";
-import { updateTemplateToLatestInstance, stringifyJSONArray, removeMostRecentTemplate, getTemplateVersion, JSONStringArray } from "./util/templateutils";
+import { updateTemplateToLatestInstance, removeMostRecentTemplate, getTemplateVersion } from "./util/templateutils";
 
 export class TemplateServiceClient {
   private storageProvider: StorageProvider;
@@ -101,8 +101,8 @@ export class TemplateServiceClient {
   }
 
   /**
-   * @public 
-   * Public update user info function. 
+   * @public
+   * Public update user info function.
    * @param {string} firstName
    * @param {string}lastName
    * @param {string[]} team
@@ -123,7 +123,15 @@ export class TemplateServiceClient {
    * @param {string[]} recentlyEdited - list of template ids last edited by the logged in user, should be of length 5 or less
    * @param {string[]} recentTags - list of tags lsat used by the logged in user, should be of length 10 or less
    */
-  private async _updateUser(firstName?: string, lastName?: string, team?: string[], org?: string[], recentlyViewed?: string[], recentlyEdited?: string[], recentTags?: string[]): Promise<JSONResponse<Number>> {
+  private async _updateUser(
+    firstName?: string,
+    lastName?: string,
+    team?: string[],
+    org?: string[],
+    recentlyViewed?: string[],
+    recentlyEdited?: string[],
+    recentTags?: string[]
+  ): Promise<JSONResponse<Number>> {
     let checkAuthentication = this._checkAuthenticated();
     if (!checkAuthentication.success) {
       return checkAuthentication;
@@ -131,18 +139,18 @@ export class TemplateServiceClient {
 
     const userQuery: Partial<IUser> = {
       authId: this.authProvider.getOwner()!,
-      authIssuer: this.authProvider.issuer, 
-    }
+      authIssuer: this.authProvider.issuer
+    };
 
-    const user : Partial<IUser> = {
-      firstName: firstName, 
-      lastName: lastName, 
+    const user: Partial<IUser> = {
+      firstName: firstName,
+      lastName: lastName,
       team: team,
       org: org,
-      recentlyViewedTemplates: recentlyViewed, 
+      recentlyViewedTemplates: recentlyViewed,
       recentlyEditedTemplates: recentlyEdited,
       recentTags: recentTags
-    }
+    };
 
     return this.storageProvider.updateUser(userQuery, user);
   }
@@ -169,7 +177,7 @@ export class TemplateServiceClient {
   /**
    * @private
    * Get other user's public info: {firstName, lastName, team, org}
-   * Used by the template preview. 
+   * Used by the template preview.
    */
   private async _searchUserInfo(id: string): Promise<JSONResponse<UserPreview>> {
     const query: Partial<IUser> = {
@@ -177,7 +185,7 @@ export class TemplateServiceClient {
     };
 
     let response = await this.storageProvider.getUsers(query);
-    if (!response.success || response.result && response.result.length === 0){
+    if (!response.success || (response.result && response.result.length === 0)) {
       return { success: false, errorMessage: ServiceErrorMessage.UserNotFound };
     }
 
@@ -187,28 +195,29 @@ export class TemplateServiceClient {
       lastName: user.lastName || "",
       team: user.team,
       org: user.org
-    }
+    };
 
     return { success: true, result: userInfo };
   }
-  
+
   /**
    * @private
    * Creates new user object, updates instance ownerID if successful.
    * @param {string[]} team - user's team within org
    * @param {string[]} org - user's organization
-   * @param {string} firstName 
+   * @param {string} firstName
    * @param {string} lastName
-   * @param {string[]} recentlyViewed - list of ids of 
+   * @param {string[]} recentlyViewed - list of ids of
    */
   private async _postUser(
-    team?: string[], 
-    org?: string[], 
-    firstName?: string, 
-    lastName?: string, 
-    recentlyViewed?: string[], 
-    recentlyEdited?: string[], 
-    recentTags?: string[]): Promise<JSONResponse<string>> {
+    team?: string[],
+    org?: string[],
+    firstName?: string,
+    lastName?: string,
+    recentlyViewed?: string[],
+    recentlyEdited?: string[],
+    recentTags?: string[]
+  ): Promise<JSONResponse<string>> {
     let checkAuthentication = this._checkAuthenticated();
     if (!checkAuthentication.success) {
       return checkAuthentication;
@@ -221,8 +230,8 @@ export class TemplateServiceClient {
       lastName: lastName || "",
       team: team || [],
       org: org || [],
-      recentlyViewedTemplates: recentlyViewed || [], 
-      recentlyEditedTemplates: recentlyEdited || [], 
+      recentlyViewedTemplates: recentlyViewed || [],
+      recentlyEditedTemplates: recentlyEdited || [],
       recentTags: recentTags || []
     };
 
@@ -266,18 +275,15 @@ export class TemplateServiceClient {
    * @param template
    * @param version - If provided, only specific version numHits is incremented
    */
-  private async _incrementTemplateHits(
-    templateId: string, 
-    template: ITemplate,
-    version?: string): Promise<JSONResponse<Number>> {
+  private async _incrementTemplateHits(templateId: string, template: ITemplate, version?: string): Promise<JSONResponse<Number>> {
     const queryTemplate: Partial<ITemplate> = {
-      _id: templateId,
+      _id: templateId
     };
 
     if (!template.instances) {
       return { success: true };
     }
-    
+
     let templateInstances = [];
     for (let instance of template.instances) {
       if (!version || version === instance.version) {
@@ -296,14 +302,14 @@ export class TemplateServiceClient {
   /**
    * @private
    * Returns either all published or unpublished templates
-   * @param template 
+   * @param template
    * @param isPublished
    */
   private _getPublishedTemplates(template: ITemplate, isPublished: boolean): ITemplate {
     if (!template.instances || template.instances.length === 0) return template;
     let templateInstances: ITemplateInstance[] = [];
-    for (let instance of template.instances){
-      if ((isPublished && instance.state === TemplateState.live) || (!isPublished && instance.state !== TemplateState.live)){
+    for (let instance of template.instances) {
+      if ((isPublished && instance.state === TemplateState.live) || (!isPublished && instance.state !== TemplateState.live)) {
         templateInstances.push(instance);
       }
     }
@@ -312,52 +318,53 @@ export class TemplateServiceClient {
   }
 
   /**
-   * @private 
+   * @private
    * Returns either all templates owned by the user, or all templates not owned by the user.
-   * @param template 
-   * @param owned 
+   * @param template
+   * @param owned
    */
   private _getOwnedTemplates(templates: ITemplate[], owned: boolean): ITemplate[] {
     let result: ITemplate[] = [];
-    for (let instance of templates){
+    for (let instance of templates) {
       let isOwner = instance.owner === this.ownerID;
-      if (isOwner && owned || !isOwner && !owned){
+      if ((isOwner && owned) || (!isOwner && !owned)) {
         result.push(instance);
       }
     }
     return result;
   }
-  
+
   /**
    * @private
    * Updates existing template, assumes that owner user exists/has already been created.
-   * Will check that the templateId given actually exists. 
+   * Will check that the templateId given actually exists.
    * @param {string} templateId - template id to update
-   * @param {string} name 
+   * @param {string} name
    * @param {JSON} template - updated template json
    * @param {string} version - updated version number
    * @param {boolean} isPublished - if this field is set, the state will be "live" regardless of what the state input is
    * @param {TemplateState} state - "live" | "deprecated" | "draft"
    * @param {boolean} isShareable
-   * @param {string} tag - append this tag onto existing tags array 
+   * @param {string} tag - append this tag onto existing tags array
    * @param {string[]} tagList - replace existing tags with tagList
    * @param {JSON} data - append this json onto existing data array
    * @param {JSON[]} dataList - replace existing data list
    */
   private async _updateTemplate(
-    templateId: string, 
-    name?: string, 
-    template?: JSON, 
-    version?: string, 
-    isPublished?: boolean, 
-    state?: TemplateState, 
-    isShareable?: boolean, 
+    templateId: string,
+    name?: string,
+    template?: JSON,
+    version?: string,
+    isPublished?: boolean,
+    state?: TemplateState,
+    isShareable?: boolean,
     tag?: string,
     tagList?: string[],
-    data?: JSON, 
-    dataList?: JSON[]): Promise<JSONResponse<Number>> {
+    data?: JSON,
+    dataList?: JSON[]
+  ): Promise<JSONResponse<Number>> {
     const queryTemplate: Partial<ITemplate> = {
-      _id: templateId,
+      _id: templateId
     };
 
     // Check if version already exists
@@ -369,38 +376,43 @@ export class TemplateServiceClient {
     let existingTemplate: ITemplate = response.result[0];
     let templateName: string = name ? name : existingTemplate.name;
     let existingTags = existingTemplate.tags;
-    if (tag){
+    if (tag) {
       existingTags!.push(tag);
     }
-    let tags: string[] | undefined = tag? existingTags : tagList;
-    let templateState: TemplateState | undefined = isPublished? TemplateState.live : state;
+    let tags: string[] | undefined = tag ? existingTags : tagList;
+    let templateState: TemplateState | undefined = isPublished ? TemplateState.live : state;
 
     let templateInstance: ITemplateInstance = {
-      json: JSON.stringify(template),
-      version: version || "1.0", 
+      json: template ? template : JSON.parse("{}"),
+      version: version || "1.0",
       state: templateState,
-      data: [], 
-      publishedAt: isPublished? new Date(Date.now()) : undefined,
+      data: [],
+      publishedAt: isPublished ? new Date(Date.now()) : undefined,
       updatedAt: new Date(Date.now()),
       numHits: 0,
       isShareable: isShareable
-    }
+    };
 
     let templateInstances: ITemplateInstance[] = [];
     if (existingTemplate.instances) {
       // Check if updated version already exists
       let added = false;
-      for (let instance of existingTemplate.instances){
+      for (let instance of existingTemplate.instances) {
         if (instance.version === templateInstance.version) {
           let existingData = instance.data;
-          if (data){
-            existingData!.push(JSON.stringify(data));
+          if (data) {
+            existingData!.push(data);
           }
-          let templateData: string[] | undefined = data? existingData: dataList? stringifyJSONArray(dataList) : undefined;
+          let templateData: JSON[] | undefined = data ? existingData : dataList ? dataList : undefined;
           templateInstance.numHits = instance.numHits;
-          templateInstance.state = isPublished === false && templateInstance.state !== TemplateState.deprecated && templateInstance.state !== TemplateState.draft &&
-                                  instance.state !== TemplateState.deprecated && instance.state !== TemplateState.draft? TemplateState.draft : 
-                                  templateInstance.state || instance.state;
+          templateInstance.state =
+            isPublished === false &&
+            templateInstance.state !== TemplateState.deprecated &&
+            templateInstance.state !== TemplateState.draft &&
+            instance.state !== TemplateState.deprecated &&
+            instance.state !== TemplateState.draft
+              ? TemplateState.draft
+              : templateInstance.state || instance.state;
           templateInstance.data = templateData || instance.data;
           templateInstance.publishedAt = templateInstance.publishedAt || instance.publishedAt;
           templateInstance.isShareable = templateInstance.isShareable || instance.isShareable;
@@ -411,7 +423,7 @@ export class TemplateServiceClient {
         }
       }
       if (!added) {
-        let templateData: string[] | undefined = data? [JSON.stringify(data)]: dataList? stringifyJSONArray(dataList) : undefined;
+        let templateData: JSON[] | undefined = data ? [data] : dataList ? dataList : undefined;
         // Updated version does not already exist, add to instances list
         templateInstance.state = templateState || TemplateState.draft;
         templateInstance.isShareable = isShareable || false;
@@ -428,7 +440,7 @@ export class TemplateServiceClient {
       tags: tags,
       owner: this.ownerID!,
       updatedAt: new Date(Date.now()),
-      isLive: existingTemplate.isLive || isPublished,
+      isLive: existingTemplate.isLive || isPublished
     };
 
     return this.storageProvider.updateTemplate(queryTemplate, newTemplate);
@@ -443,21 +455,22 @@ export class TemplateServiceClient {
    * @param {boolean} isPublished - if template is live
    * @param {string} name - template name
    * @param {TemplateState} state - draft || deprecated || live
-   * @param {boolean} isShareable 
+   * @param {boolean} isShareable
    * @param {string[]} tags
-   * @param {JSON[]} data - sample data to be bound with template - templateID must be defined 
+   * @param {JSON[]} data - sample data to be bound with template - templateID must be defined
    * @returns Promise as valid json
    */
   public async postTemplates(
-    template: JSON, 
-    templateId?: string, 
-    version?: string, 
-    isPublished?: boolean, 
-    name?: string, 
-    state?: TemplateState, 
-    isShareable?: boolean, 
-    tags?: string[] | string, 
-    data?: JSON[] | JSON): Promise<JSONResponse<String>> {
+    template: JSON,
+    templateId?: string,
+    version?: string,
+    isPublished?: boolean,
+    name?: string,
+    state?: TemplateState,
+    isShareable?: boolean,
+    tags?: string[] | string,
+    data?: JSON[] | JSON
+  ): Promise<JSONResponse<String>> {
     let checkAuthentication = this._checkAuthenticated();
     if (!checkAuthentication.success) {
       return checkAuthentication;
@@ -470,10 +483,10 @@ export class TemplateServiceClient {
 
     // Updating existing template
     if (templateId) {
-      let tagList : string[] | undefined;
-      let tag : string | undefined;
-      let dataList : JSON[] | undefined;
-      let dataItem : JSON | undefined;
+      let tagList: string[] | undefined;
+      let tag: string | undefined;
+      let dataList: JSON[] | undefined;
+      let dataItem: JSON | undefined;
 
       if (tags instanceof Array) {
         tagList = tags;
@@ -482,7 +495,7 @@ export class TemplateServiceClient {
         tagList = undefined;
         tag = tags;
       }
-        
+
       if (data instanceof Array) {
         dataList = data;
         dataItem = undefined;
@@ -491,13 +504,25 @@ export class TemplateServiceClient {
         dataList = undefined;
       }
 
-      let response = await this._updateTemplate(templateId, name, template, version, isPublished, state, isShareable, tag, tagList, dataItem, dataList);
+      let response = await this._updateTemplate(
+        templateId,
+        name,
+        template,
+        version,
+        isPublished,
+        state,
+        isShareable,
+        tag,
+        tagList,
+        dataItem,
+        dataList
+      );
 
-      let newTags = tag? [tag]: tagList? tagList : [];
+      let newTags = tag ? [tag] : tagList ? tagList : [];
       // Update recent tags and recently edited template
       await this._updateRecentTags(newTags);
       await this._updateRecentTemplate(templateId, false);
-      
+
       if (response.success) {
         return { success: true };
       }
@@ -508,19 +533,19 @@ export class TemplateServiceClient {
     }
 
     const templateInstance: ITemplateInstance = {
-      json: JSON.stringify(template),
+      json: template,
       version: version || "1.0",
-      publishedAt: isPublished? new Date(Date.now()) : undefined,
-      state: isPublished? TemplateState.live : state? state : TemplateState.draft,
+      publishedAt: isPublished ? new Date(Date.now()) : undefined,
+      state: isPublished ? TemplateState.live : state ? state : TemplateState.draft,
       isShareable: isShareable || false,
       numHits: 0,
-      data: data? data instanceof Array? stringifyJSONArray(data) : [JSON.stringify(data)] : [],
+      data: data ? (data instanceof Array ? data : [data]) : [],
       updatedAt: new Date(Date.now())
     };
 
     let templateName = name || "Untitled Template";
 
-    let newTags = tags? tags instanceof Array? tags : [tags]: [];
+    let newTags = tags ? (tags instanceof Array ? tags : [tags]) : [];
 
     const newTemplate: ITemplate = {
       name: templateName,
@@ -529,14 +554,14 @@ export class TemplateServiceClient {
       tags: newTags,
       deletedVersions: [],
       isLive: isPublished || false,
-      updatedAt: new Date(Date.now()) 
+      updatedAt: new Date(Date.now())
     };
 
     // Update recent tags for user
     await this._updateRecentTags(newTags);
 
     let response = await this.storageProvider.insertTemplate(newTemplate);
-    if (response.success && response.result){
+    if (response.success && response.result) {
       templateId = response.result;
       await this._updateRecentTemplate(templateId, false);
     }
@@ -553,13 +578,13 @@ export class TemplateServiceClient {
 
     // Update recently viewed for user
     let user = await this._getUser();
-    if (!user.success || !user.result || user.result.length !== 1){
+    if (!user.success || !user.result || user.result.length !== 1) {
       return { success: false };
     }
-    
+
     let recentTags = user.result[0].recentTags;
-    for (let tag of tags){
-      if (recentTags!.includes(tag)){
+    for (let tag of tags) {
+      if (recentTags!.includes(tag)) {
         let index = recentTags!.indexOf(tag);
         recentTags!.splice(index, 1);
       }
@@ -573,18 +598,18 @@ export class TemplateServiceClient {
 
   /**
    * @private
-   * @param templateId 
+   * @param templateId
    * @param viewed - if true, adds given template id to viewed list for logged in user, otherwise adds to edited list
    */
   private async _updateRecentTemplate(templateId: string, viewed: boolean): Promise<JSONResponse<Number>> {
     // Update recently viewed for user
     let user = await this._getUser();
-    if (!user.success || !user.result || user.result.length !== 1){
+    if (!user.success || !user.result || user.result.length !== 1) {
       return { success: false };
     }
-    let recentList = viewed? user.result[0].recentlyViewedTemplates : user.result[0].recentlyEditedTemplates;
-    
-    if (recentList!.includes(templateId)){
+    let recentList = viewed ? user.result[0].recentlyViewedTemplates : user.result[0].recentlyEditedTemplates;
+
+    if (recentList!.includes(templateId)) {
       let index = recentList!.indexOf(templateId);
       recentList!.splice(index, 1);
     }
@@ -592,7 +617,7 @@ export class TemplateServiceClient {
       recentList!.shift();
     }
     recentList!.push(templateId);
-    if (viewed){
+    if (viewed) {
       return await this._updateUser(undefined, undefined, undefined, undefined, recentList);
     }
     return await this._updateUser(undefined, undefined, undefined, undefined, undefined, recentList);
@@ -619,10 +644,10 @@ export class TemplateServiceClient {
     templateName?: string,
     version?: string,
     owned?: boolean,
-    sortBy?: SortBy, 
-    sortOrder?: SortOrder, 
+    sortBy?: SortBy,
+    sortOrder?: SortOrder,
     tags?: string[],
-    isClient?: boolean,
+    isClient?: boolean
   ): Promise<JSONResponse<ITemplate[]>> {
     let checkAuthentication = this._checkAuthenticated();
     if (!checkAuthentication.success) {
@@ -638,26 +663,26 @@ export class TemplateServiceClient {
         };
     }
 
-    const templateQuery : Partial<ITemplate> = {
+    const templateQuery: Partial<ITemplate> = {
       _id: templateId,
       name: templateName,
       tags: tags,
-      owner: owned? this.ownerID : undefined
+      owner: owned ? this.ownerID : undefined
     };
 
     let response = await this.storageProvider.getTemplates(templateQuery, sortBy, sortOrder);
 
-    if (!response.success || !response.result ) return response;
+    if (!response.success || !response.result) return response;
 
     let templates: ITemplate[] = response.result;
 
     if (owned === false) {
       templates = this._getOwnedTemplates(templates, owned);
     }
-    
+
     if (isPublished || isPublished === false) {
       let templatesFiltered = [];
-      for (let template of templates){
+      for (let template of templates) {
         let templateInstance = this._getPublishedTemplates(template, isPublished);
         if (template.instances && template.instances.length > 0) {
           templatesFiltered.push(templateInstance);
@@ -678,11 +703,11 @@ export class TemplateServiceClient {
     }
 
     // Filter for the latest template version (instance)
-    let resultTemplates : ITemplate[] = [];
+    let resultTemplates: ITemplate[] = [];
     for (let template of templates) {
       if (!template.instances) continue;
       if (version) {
-        for (let instance of template.instances){
+        for (let instance of template.instances) {
           if (version && instance.version === version) {
             template.instances = [instance];
             resultTemplates.push(template);
@@ -699,11 +724,11 @@ export class TemplateServiceClient {
 
   /**
    * @public
-   * Delete template endpoint. 
-   * If the only template version is deleted, the entire template object is deleted. 
-   * If a version is not specified, the last version is deleted. 
+   * Delete template endpoint.
+   * If the only template version is deleted, the entire template object is deleted.
+   * If a version is not specified, the last version is deleted.
    * @param {string} templateId
-   * @param {string} version 
+   * @param {string} version
    */
   public async deleteTemplate(templateId: string, version?: string): Promise<JSONResponse<Number>> {
     let checkAuthentication = this._checkAuthenticated();
@@ -713,7 +738,7 @@ export class TemplateServiceClient {
 
     // Get template instance, check owner and isPublished
     let response = await this.getTemplates(templateId);
-    if (!response.success || !response.result ) {
+    if (!response.success || !response.result) {
       return { success: false, errorMessage: response.errorMessage };
     }
     if (response.result.length === 0) {
@@ -722,20 +747,20 @@ export class TemplateServiceClient {
     let template = response.result[0];
 
     if (template.owner !== this.ownerID || template.isLive) {
-      return { success: false, errorMessage: ServiceErrorMessage.UnauthorizedAction }
+      return { success: false, errorMessage: ServiceErrorMessage.UnauthorizedAction };
     }
 
     // No instances, delete template object entirely
     if (!template.instances) {
-      return this.storageProvider.removeTemplate({_id: templateId});
+      return this.storageProvider.removeTemplate({ _id: templateId });
     }
 
-    let templateObj : ITemplate;
+    let templateObj: ITemplate;
     if (!version) {
       templateObj = removeMostRecentTemplate(template);
     } else {
       let templateInstances = [];
-      for (let instance of template.instances){
+      for (let instance of template.instances) {
         if (instance.version !== version) {
           templateInstances.push(instance);
         }
@@ -747,12 +772,12 @@ export class TemplateServiceClient {
 
     // No instances, delete template object entirely
     if (templateObj.instances && templateObj.instances.length === 0) {
-      return this.storageProvider.removeTemplate({_id: templateId});
+      return this.storageProvider.removeTemplate({ _id: templateId });
     }
 
     const query: Partial<ITemplate> = {
       _id: templateId
-    }
+    };
 
     return this.storageProvider.updateTemplate(query, templateObj);
   }
@@ -766,10 +791,10 @@ export class TemplateServiceClient {
   public async getTemplatePreview(templateId: string, version: string): Promise<JSONResponse<TemplatePreview>> {
     const templateQuery: Partial<ITemplate> = {
       _id: templateId
-    }
+    };
 
     let response = await this.storageProvider.getTemplates(templateQuery);
-    if (!response.success || response.result && response.result.length === 0){
+    if (!response.success || (response.result && response.result.length === 0)) {
       return { success: false, errorMessage: ServiceErrorMessage.FailedToRetrievePreview };
     }
 
@@ -780,24 +805,24 @@ export class TemplateServiceClient {
     }
 
     let templateInstance: TemplateInstancePreview = {
-      version: version, 
-      json: JSON.parse(templateVersion.json),
+      version: version,
+      json: templateVersion.json,
       state: templateVersion.state || TemplateState.draft,
-      data: templateVersion.data? JSONStringArray(templateVersion.data) : []
-    }
+      data: templateVersion.data ? templateVersion.data : []
+    };
 
     let userInfo = await this._searchUserInfo(template.owner);
     if (!userInfo.success || !userInfo.result) {
       return { success: false, errorMessage: ServiceErrorMessage.FailedToRetrievePreview };
     }
 
-    let templatePreview : TemplatePreview = {
-      _id: templateId, 
+    let templatePreview: TemplatePreview = {
+      _id: templateId,
       name: template.name,
       owner: userInfo.result!,
       instance: templateInstance,
-      tags: template.tags || [],
-    }
+      tags: template.tags || []
+    };
 
     return { success: true, result: templatePreview };
   }
@@ -814,26 +839,26 @@ export class TemplateServiceClient {
 
     let results: ITemplate[] = [];
     let response = await this._getUser();
-    if (!response.success || response.result && response.result.length === 0) {
+    if (!response.success || (response.result && response.result.length === 0)) {
       return { success: false, errorMessage: response.errorMessage };
     }
 
     let user: IUser = response.result![0];
-    if (viewed && !user.recentlyViewedTemplates || !viewed && !user.recentlyEditedTemplates) {
+    if ((viewed && !user.recentlyViewedTemplates) || (!viewed && !user.recentlyEditedTemplates)) {
       return { success: true, result: results };
     }
 
-    let templateList = viewed? user.recentlyViewedTemplates: user.recentlyEditedTemplates;
+    let templateList = viewed ? user.recentlyViewedTemplates : user.recentlyEditedTemplates;
     for (let templateId of templateList!) {
       let templateResponse = await this.getTemplates(templateId);
-      if (templateResponse.success && templateResponse.result && templateResponse.result.length === 1){
+      if (templateResponse.success && templateResponse.result && templateResponse.result.length === 1) {
         results.push(templateResponse.result[0]);
       }
     }
     return { success: true, result: results };
   }
   /**
-   * @public 
+   * @public
    * Retrieve a list of recently viewed templates for the logged in user.
    */
   public async getRecentlyViewedTemplates(): Promise<JSONResponse<ITemplate[]>> {
@@ -859,7 +884,7 @@ export class TemplateServiceClient {
     }
 
     let response = await this._getUser();
-    if (!response.success || response.result && response.result.length === 0) {
+    if (!response.success || (response.result && response.result.length === 0)) {
       return { success: false, errorMessage: response.errorMessage };
     }
 
@@ -884,12 +909,12 @@ export class TemplateServiceClient {
     for (let template of response.result) {
       if (!template.tags) continue;
       if (template.owner === this.ownerID) {
-        for (let tag of template.tags){
+        for (let tag of template.tags) {
           ownedTags.add(tag);
         }
       }
-      if (template.isLive){
-        for (let tag of template.tags){
+      if (template.isLive) {
+        for (let tag of template.tags) {
           allTags.add(tag);
         }
       }
@@ -898,8 +923,8 @@ export class TemplateServiceClient {
     let list: TagList = {
       ownedTags: Array.from(ownedTags),
       allTags: Array.from(allTags)
-    }
-    return { success: true, result: list};
+    };
+    return { success: true, result: list };
   }
 
   /**
@@ -938,25 +963,34 @@ export class TemplateServiceClient {
     router.all("/", this._routerAuthentication);
 
     router.get("/", (req: Request, res: Response, _next: NextFunction) => {
-      if (req.query.sortBy && !(req.query.sortBy in SortBy)){
+      if (req.query.sortBy && !(req.query.sortBy in SortBy)) {
         const err = new TemplateError(ApiError.InvalidQueryParam, "Sort by value is not valid.");
         res.status(400).json({ error: err });
       }
 
-      if (req.query.sortOrder && !(req.query.sortOrder in SortOrder)){
+      if (req.query.sortOrder && !(req.query.sortOrder in SortOrder)) {
         const err = new TemplateError(ApiError.InvalidQueryParam, "Sort order value is not valid.");
         res.status(400).json({ error: err });
       }
 
-      let isPublished: boolean | undefined = req.query.isPublished? req.query.isPublished === "true" || req.query.isPublished === "True": undefined;
-      let owned: boolean | undefined = req.query.owned? req.query.owned === "true" || req.query.owned === "True": undefined;
+      let isPublished: boolean | undefined = req.query.isPublished ? req.query.isPublished === "true" || req.query.isPublished === "True" : undefined;
+      let owned: boolean | undefined = req.query.owned ? req.query.owned === "true" || req.query.owned === "True" : undefined;
       let isClient: boolean = req.body.isClient;
-      if (!req.is('application/json')) {
+      if (!req.is("application/json")) {
         isClient = req.body.isClient === "true" || req.body.isClient === "True";
       }
 
-      this.getTemplates(undefined, isPublished, req.query.name, req.query.version, 
-        owned, req.query.sortBy, req.query.sortOrder, req.body.tags, isClient).then(response => {
+      this.getTemplates(
+        undefined,
+        isPublished,
+        req.query.name,
+        req.query.version,
+        owned,
+        req.query.sortBy,
+        req.query.sortOrder,
+        req.body.tags,
+        isClient
+      ).then(response => {
         if (!response.success) {
           return res.status(200).json({ templates: [] });
         }
@@ -967,7 +1001,7 @@ export class TemplateServiceClient {
     router.get("/recent", async (_req: Request, res: Response, _next: NextFunction) => {
       let response = await this.getRecentlyViewedTemplates();
       let recentlyViewedTemplates: ITemplate[] = [];
-      if (response.success && response.result) {  
+      if (response.success && response.result) {
         recentlyViewedTemplates = response.result;
       }
 
@@ -986,7 +1020,7 @@ export class TemplateServiceClient {
       res.status(200).json({
         recentlyViewed: {
           templates: recentlyViewedTemplates
-        }, 
+        },
         recentlyEdited: {
           templates: recentlyEditedTemplates
         },
@@ -998,26 +1032,28 @@ export class TemplateServiceClient {
 
     router.get("/tag", (_req: Request, res: Response, _next: NextFunction) => {
       this.getTags().then(response => {
-        if (!response.success){
+        if (!response.success) {
           return res.status(400).send();
         }
         res.status(200).json(response.result);
-      })
+      });
     });
 
     router.get("/:id?", (req: Request, res: Response, _next: NextFunction) => {
       let isClient: boolean = req.body.isClient;
-      if (!req.is('application/json')) {
+      if (!req.is("application/json")) {
         isClient = req.body.isClient === "true" || req.body.isClient === "True";
       }
 
-      this.getTemplates(req.params.id, undefined, undefined, req.query.version, undefined, undefined, undefined, undefined, isClient).then(response => {
-        if (!response.success || (response.result && response.result.length === 0)) {
-          const err = new TemplateError(ApiError.TemplateNotFound, `Template with id ${req.params.id} does not exist.`);
-          return res.status(404).json({ error: err });
+      this.getTemplates(req.params.id, undefined, undefined, req.query.version, undefined, undefined, undefined, undefined, isClient).then(
+        response => {
+          if (!response.success || (response.result && response.result.length === 0)) {
+            const err = new TemplateError(ApiError.TemplateNotFound, `Template with id ${req.params.id} does not exist.`);
+            return res.status(404).json({ error: err });
+          }
+          res.status(200).json({ templates: response.result });
         }
-        res.status(200).json({ templates: response.result });
-      });
+      );
     });
 
     router.get("/:id/preview", (req: Request, res: Response, _next: NextFunction) => {
@@ -1027,33 +1063,43 @@ export class TemplateServiceClient {
           return res.status(404).json({ error: err });
         }
         res.status(200).json({ template: response.result });
-      })
-    })
+      });
+    });
 
     router.post("/:id*?", async (req: Request, res: Response, _next: NextFunction) => {
-      await check("template", "Template is not valid JSON.")
-        .isJSON()
-        .run(req);
-      const errors = validationResult(req);
-
-      if (!errors.isEmpty()) {
-        const err = new TemplateError(ApiError.InvalidTemplate, "Template is incorrectly formatted.");
-        return res.status(400).json({ error: err });
-      }
-
       let isPublished: boolean = req.body.isPublished;
       let isShareable: boolean = req.body.isShareable;
-      if (!req.is('application/json')) {
+      if (!req.is("application/json")) {
         isPublished = req.body.isPublished === "true" || req.body.isPublished === "True";
         isShareable = req.body.isShareable === "true" || req.body.isShareable === "True";
       }
-      
+
       let tags: string[] | string = req.body.tags;
       let data: JSON[] | JSON = req.body.data;
 
-      let response = req.params.id ?
-        await this.postTemplates(req.body.template, req.params.id, req.body.version, isPublished, req.body.name, req.body.state, isShareable, tags, data) :
-        await this.postTemplates(req.body.template, undefined, req.body.version, isPublished, req.body.name, req.body.state, isShareable, tags, data);
+      let response = req.params.id
+        ? await this.postTemplates(
+            req.body.template,
+            req.params.id,
+            req.body.version,
+            isPublished,
+            req.body.name,
+            req.body.state,
+            isShareable,
+            tags,
+            data
+          )
+        : await this.postTemplates(
+            req.body.template,
+            undefined,
+            req.body.version,
+            isPublished,
+            req.body.name,
+            req.body.state,
+            isShareable,
+            tags,
+            data
+          );
 
       if (!response.success) {
         const err = new TemplateError(ApiError.InvalidTemplate, "Unable to create given template.");
@@ -1065,13 +1111,13 @@ export class TemplateServiceClient {
 
     router.delete("/:id*?", (req: Request, res: Response, _next: NextFunction) => {
       this.deleteTemplate(req.params.id, req.query.version).then(response => {
-        if (!response.success){
+        if (!response.success) {
           const err = new TemplateError(ApiError.DeleteTemplateVersionFailed, `Failed to delete template ${req.params.id} version.`);
           return res.status(404).json({ error: err });
         }
         res.status(204).send();
-      })
-    })
+      });
+    });
     return router;
   }
 
@@ -1098,11 +1144,11 @@ export class TemplateServiceClient {
 
     router.post("/", (req: Request, res: Response, _next: NextFunction) => {
       this.updateUser(req.body.firstName, req.body.lastName, req.body.team, req.body.org).then(response => {
-        if (!response.success){
+        if (!response.success) {
           return res.status(400);
         }
         res.status(200).send();
-      })
+      });
     });
 
     router.delete("/", (_req: Request, res: Response, _next: NextFunction) => {

--- a/private-templates-service/adaptivecards-templating-service/src/models/models.ts
+++ b/private-templates-service/adaptivecards-templating-service/src/models/models.ts
@@ -8,18 +8,18 @@
  * @property {string} lastName
  * @property {string[]} team
  * @property {string[]} org
- * @property {string[]} recentlyViewed - list of 5 templates that were last viewed (GET /template/{id}) by logged in user 
+ * @property {string[]} recentlyViewed - list of 5 templates that were last viewed (GET /template/{id}) by logged in user
  */
 
 export interface ITemplateInstance {
   _id?: string;
-  json: string;
+  json: JSON;
   version: string;
   publishedAt?: Date;
   state?: TemplateState;
   isShareable?: boolean;
   numHits?: number;
-  data?: string[];
+  data?: JSON[];
   updatedAt?: Date;
   createdAt?: Date;
 }
@@ -96,10 +96,10 @@ export interface TemplateInstancePreview {
  * User information that is viewable by client.
  */
 export interface UserPreview {
-	firstName: string;
-	lastName: string;
-	team?: string[];
-	org?: string[];
+  firstName: string;
+  lastName: string;
+  team?: string[];
+  org?: string[];
 }
 
 /**
@@ -120,5 +120,5 @@ export interface TemplatePreview {
  */
 export interface TagList {
   ownedTags: any[];
-  allTags: any[]
+  allTags: any[];
 }

--- a/private-templates-service/adaptivecards-templating-service/src/models/mongo/TemplateModel.ts
+++ b/private-templates-service/adaptivecards-templating-service/src/models/mongo/TemplateModel.ts
@@ -13,13 +13,13 @@ export interface ITemplateModel extends mongoose.Document, ITemplate {
 export const TemplateInstanceSchema: Schema = new Schema(
   {
     _id: { type: String, required: true },
-    json: { type: String, required: true },
+    json: { type: String, required: true, set: MongoUtils.jsonToString },
     version: { type: String, required: true },
     publishedAt: { type: Date, default: null },
     state: { type: String, default: TemplateState.draft },
     isShareable: { type: Boolean, default: false },
     hits: { type: Number, default: 0 },
-    data: { type: [String], default: [] }
+    data: { type: [String], default: [], set: MongoUtils.jsonArrayToString }
   },
   {
     versionKey: false,

--- a/private-templates-service/adaptivecards-templating-service/src/storageproviders/MongoDBProvider.ts
+++ b/private-templates-service/adaptivecards-templating-service/src/storageproviders/MongoDBProvider.ts
@@ -45,6 +45,7 @@ export class MongoDBProvider implements StorageProvider {
   async getUsers(query: Partial<IUser>): Promise<JSONResponse<IUser[]>> {
     let userQuery: any = this._constructUserQuery(query);
     return await this.worker.User.find(userQuery)
+      .lean()
       .then(users => {
         if (users.length) {
           return Promise.resolve({
@@ -63,9 +64,17 @@ export class MongoDBProvider implements StorageProvider {
   }
 
   // Default sort is by name and in ascending order.
-  async getTemplates(query: Partial<ITemplate>, sortBy: SortBy = SortBy.alphabetical, sortOrder: SortOrder = SortOrder.ascending): Promise<JSONResponse<ITemplate[]>> {
+  async getTemplates(
+    query: Partial<ITemplate>,
+    sortBy: SortBy = SortBy.alphabetical,
+    sortOrder: SortOrder = SortOrder.ascending
+  ): Promise<JSONResponse<ITemplate[]>> {
     let templateQuery: any = this._constructTemplateQuery(query);
     return await this.worker.Template.find(templateQuery, {})
+      .lean()
+      .map(templateModels => {
+        return MongoUtils.restoreJSONTypeOfTemplate(templateModels);
+      })
       .sort({ [sortBy]: sortOrder })
       .then(templates => {
         if (templates.length) {
@@ -88,6 +97,7 @@ export class MongoDBProvider implements StorageProvider {
     let userQuery: any = this._constructUserQuery(query);
     updateQuery = MongoUtils.removeUndefinedFields(updateQuery);
     return await this.worker.User.findOneAndUpdate(userQuery, updateQuery)
+      .lean()
       .then(result => {
         if (result) {
           return Promise.resolve({
@@ -110,6 +120,7 @@ export class MongoDBProvider implements StorageProvider {
     let templateQuery: any = this._constructTemplateQuery(query);
     updateQuery = MongoUtils.removeUndefinedFields(updateQuery);
     return await this.worker.Template.findOneAndUpdate(templateQuery, updateQuery)
+      .lean()
       .then(result => {
         if (result) {
           return Promise.resolve({ success: true });

--- a/private-templates-service/adaptivecards-templating-service/src/tests/router.test.ts
+++ b/private-templates-service/adaptivecards-templating-service/src/tests/router.test.ts
@@ -28,7 +28,7 @@ export default async function getToken(): Promise<string> {
         let parsedBody = JSON.parse(body);
         if (parsedBody.error_description) {
           console.log("Error=" + parsedBody.error_description);
-          return Promise.resolve("hi");
+          return Promise.resolve(parsedBody.error_description);
         } else {
           console.log("Access Token=" + parsedBody.access_token);
           return Promise.resolve(parsedBody.access_token);

--- a/private-templates-service/adaptivecards-templating-service/src/tests/router.test.ts
+++ b/private-templates-service/adaptivecards-templating-service/src/tests/router.test.ts
@@ -8,36 +8,34 @@ import bodyParser from "body-parser";
 import { InMemoryDBProvider } from "../storageproviders/InMemoryDBProvider";
 import { ITemplate, ITemplateInstance } from "../models/models";
 
-export default async function getToken(): Promise<string> {
-    const request = require('request-promise');
-    const endpoint = "https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47/oauth2/token";
-    const requestParams = {
-      grant_type: "client_credentials",
-      client_id: "4803f66a-136d-4155-a51e-6d98400d5506",
-      client_secret: "#{secrets.AZURE_ADAPTIVECMS_CLIENT_SECRET}#",
-      resource: "https://graph.windows.net"
-    };
-    return await request.post({ url: endpoint, form: requestParams })
-      // put in try catch
-      .then((err: any, response: any, body: any) => {
-        if (err) {
-          let parsedBody = JSON.parse(err);
-          return Promise.resolve(parsedBody.access_token);
-        }
-        else {
-          console.log("Body=" + body);
-          let parsedBody = JSON.parse(body);
-          if (parsedBody.error_description) {
-            console.log("Error=" + parsedBody.error_description);
-            return Promise.resolve("hi");
-          }
-          else {
-            console.log("Access Token=" + parsedBody.access_token);
-            return Promise.resolve(parsedBody.access_token);
-          }
-        }
-      });
-  }
+export default async function getToken(): Promise<string> {
+  const request = require("request-promise");
+  const endpoint = "https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47/oauth2/token";
+  const requestParams = {
+    grant_type: "client_credentials",
+    client_id: "4803f66a-136d-4155-a51e-6d98400d5506",
+    client_secret: "#{secrets.AZURE_ADAPTIVECMS_CLIENT_SECRET}#",
+    resource: "https://graph.windows.net"
+  };
+  return await request
+    .post({ url: endpoint, form: requestParams }) // put in try catch
+    .then((err: any, response: any, body: any) => {
+      if (err) {
+        let parsedBody = JSON.parse(err);
+        return Promise.resolve(parsedBody.access_token);
+      } else {
+        console.log("Body=" + body);
+        let parsedBody = JSON.parse(body);
+        if (parsedBody.error_description) {
+          console.log("Error=" + parsedBody.error_description);
+          return Promise.resolve("hi");
+        } else {
+          console.log("Access Token=" + parsedBody.access_token);
+          return Promise.resolve(parsedBody.access_token);
+        }
+      }
+    });
+}
 
 let options: ClientOptions = {
   authenticationProvider: new AzureADProvider(),
@@ -133,7 +131,7 @@ describe("Basic Post Templates", () => {
     let res = await request(app)
       .get(`/template/${id}`)
       .set({ Authorization: "Bearer " + token });
-    
+
     expect(res.status).toEqual(200);
     expect(res.body).toHaveProperty("templates");
     expect(res.body.templates).toHaveLength(1);
@@ -154,19 +152,19 @@ describe("Basic Post Templates", () => {
       .send({
         template: "{}"
       });
-    expect(res.status).toEqual(201);    
+    expect(res.status).toEqual(201);
     expect(res.body).toHaveProperty("id");
     id = res.body.id;
     idsToDelete.push(id);
 
     res = await request(app)
-    .post(`/template/${id}`)
-    .set({ Authorization: "Bearer " + token })
-    .send({
-      template: "{}", 
-      version: "1.2"
-    });
-    expect(res.status).toEqual(201); 
+      .post(`/template/${id}`)
+      .set({ Authorization: "Bearer " + token })
+      .send({
+        template: "{}",
+        version: "1.2"
+      });
+    expect(res.status).toEqual(201);
     idsToDelete.push(res.body.id);
 
     res = await request(app)
@@ -208,7 +206,7 @@ describe("Basic Post Templates", () => {
 
   afterAll(async () => {
     await mongoose.connection.close();
-    for (let id of idsToDelete){
+    for (let id of idsToDelete) {
       await request(app).delete(`/template/${id}`);
     }
   });
@@ -254,19 +252,19 @@ describe("Basic Get Templates", () => {
       .send({
         template: "{}"
       });
-    expect(res.status).toEqual(201);    
+    expect(res.status).toEqual(201);
     expect(res.body).toHaveProperty("id");
     id = res.body.id;
     idsToDelete.push(id);
 
     res = await request(app)
-    .post(`/template/${id}`)
-    .set({ Authorization: "Bearer " + token })
-    .send({
-      template: "{}", 
-      version: "1.2"
-    });
-    expect(res.status).toEqual(201); 
+      .post(`/template/${id}`)
+      .set({ Authorization: "Bearer " + token })
+      .send({
+        template: "{}",
+        version: "1.2"
+      });
+    expect(res.status).toEqual(201);
     idsToDelete.push(id);
 
     res = await request(app)
@@ -294,7 +292,7 @@ describe("Basic Get Templates", () => {
   });
 
   afterAll(async () => {
-    for (let id of idsToDelete){
+    for (let id of idsToDelete) {
       await request(app).delete(`/template/${id}`);
     }
   });
@@ -328,9 +326,8 @@ describe("Preview Templates", () => {
     expect(res.body).toHaveProperty("id");
     id = res.body.id;
     idsToDelete.push(id);
-    
-    res = await request(app)
-      .get(`/template/${id}/preview?version=1.2`)
+
+    res = await request(app).get(`/template/${id}/preview?version=1.2`);
     expect(res.body).toHaveProperty("template");
     let template = res.body.template;
     expect(template).toHaveProperty("_id");
@@ -352,8 +349,7 @@ describe("Preview Templates", () => {
   });
 
   it("should try to get posted template preview without passing version and fail", async () => {
-    const res = await request(app)
-      .get(`/template/${id}/preview`)
+    const res = await request(app).get(`/template/${id}/preview`);
     expect(res.status).toEqual(404);
   });
 
@@ -371,8 +367,7 @@ describe("Preview Templates", () => {
     id = res.body.id;
     idsToDelete.push(id);
 
-    res = await request(app)
-      .get(`/template/${id}`);
+    res = await request(app).get(`/template/${id}`);
     expect(res.status).toEqual(200);
     expect(res.body).toHaveProperty("templates");
     expect(res.body.templates).toHaveLength(1);
@@ -381,13 +376,12 @@ describe("Preview Templates", () => {
     expect(template.instances[0]).toHaveProperty("isShareable");
     expect(template.instances[0].isShareable).toEqual(false);
 
-    res = await request(app)
-      .get(`/template/${id}/preview?version=1.0`);
+    res = await request(app).get(`/template/${id}/preview?version=1.0`);
     expect(res.status).toEqual(404);
   });
 
   afterAll(async () => {
-    for (let id of idsToDelete){
+    for (let id of idsToDelete) {
       await request(app).delete(`/template/${id}`);
     }
   });
@@ -419,12 +413,10 @@ describe("Delete Templates", () => {
     expect(res.body).toHaveProperty("id");
     id = res.body.id;
 
-    res = await request(app)
-      .delete(`/template/${id}`);
+    res = await request(app).delete(`/template/${id}`);
     expect(res.status).toEqual(204);
 
-    res = await request(app)
-      .get(`/template/${id}`);
+    res = await request(app).get(`/template/${id}`);
     expect(res.status).toEqual(404);
   });
 
@@ -441,30 +433,27 @@ describe("Delete Templates", () => {
     idsToDelete.push(id);
 
     res = await request(app)
-    .post(`/template/${id}`)
-    .set({ Authorization: "Bearer " + token })
-    .send({
-      template: "{}",
-      version: "1.4"
-    });
+      .post(`/template/${id}`)
+      .set({ Authorization: "Bearer " + token })
+      .send({
+        template: "{}",
+        version: "1.4"
+      });
     expect(res.status).toEqual(201);
 
-    res = await request(app)
-      .delete(`/template/${id}?version=1.4`);
+    res = await request(app).delete(`/template/${id}?version=1.4`);
     expect(res.status).toEqual(204);
 
-    res = await request(app)
-      .get(`/template/${id}?version=1.4`);
+    res = await request(app).get(`/template/${id}?version=1.4`);
     expect(res.status).toEqual(404);
 
-    res = await request(app)
-    .get(`/template/${id}`);
+    res = await request(app).get(`/template/${id}`);
     expect(res.status).toEqual(200);
     expect(res.body.templates[0].instances[0].version).toEqual("1.0");
   });
 
   afterAll(async () => {
-    for (let id of idsToDelete){
+    for (let id of idsToDelete) {
       await request(app).delete(`/template/${id}`);
     }
   });
@@ -487,28 +476,24 @@ describe("Filtering Templates", () => {
 
   it("should try to filter template by tag and succeed", async () => {
     let res = await request(app)
-    .post("/template")
-    .set({ Authorization: "Bearer " + token })
-    .send({
-      template: "{}",
-      tags: [
-        "weather"
-      ]
-    });
+      .post("/template")
+      .set({ Authorization: "Bearer " + token })
+      .send({
+        template: "{}",
+        tags: ["weather"]
+      });
     expect(res.status).toEqual(201);
     expect(res.body).toHaveProperty("id");
     id = res.body.id;
     idsToDelete.push(id);
 
     res = await request(app)
-    .post("/template")
-    .set({ Authorization: "Bearer " + token })
-    .send({
-      template: "{}",
-      tags: [
-        "sunny"
-      ]
-    });
+      .post("/template")
+      .set({ Authorization: "Bearer " + token })
+      .send({
+        template: "{}",
+        tags: ["sunny"]
+      });
     expect(res.status).toEqual(201);
     idsToDelete.push(res.body.id);
 
@@ -516,16 +501,14 @@ describe("Filtering Templates", () => {
       .get("/template")
       .set({ Authorization: "Bearer " + token })
       .send({
-        tags: [
-          "weather"
-        ]
+        tags: ["weather"]
       });
     expect(res.status).toEqual(200);
     expect(res.body.templates).toHaveLength(1);
   });
 
   afterAll(async () => {
-    for (let id of idsToDelete){
+    for (let id of idsToDelete) {
       await request(app).delete(`/template/${id}`);
     }
   });
@@ -552,18 +535,15 @@ describe("Get Tags", () => {
       .set({ Authorization: "Bearer " + token })
       .send({
         template: "{}",
-        tags: [
-          "weather"
-        ],
+        tags: ["weather"],
         isPublished: false
       });
     expect(res.status).toEqual(201);
     expect(res.body).toHaveProperty("id");
     id = res.body.id;
     idsToDelete.push(id);
-    
-    res = await request(app)
-      .get(`/template/${id}`)
+
+    res = await request(app).get(`/template/${id}`);
     expect(res.body).toHaveProperty("templates");
     expect(res.body.templates).toHaveLength(1);
     let template = res.body.templates[0];
@@ -571,16 +551,14 @@ describe("Get Tags", () => {
     expect(template.tags[0]).toEqual("weather");
 
     res = await request(app)
-    .post("/template")
-    .set({ Authorization: "Bearer " + token })
-    .send({
-      template: "{}",
-      tags: [
-        "contosa"
-      ],
-      isPublished: true
-    });
-    expect(res.status).toEqual(201);    
+      .post("/template")
+      .set({ Authorization: "Bearer " + token })
+      .send({
+        template: "{}",
+        tags: ["contosa"],
+        isPublished: true
+      });
+    expect(res.status).toEqual(201);
     expect(res.body).toHaveProperty("id");
     await request(app).delete(`/template/${res.body.id}`);
     idsToDelete.push(res.body.id);
@@ -588,8 +566,7 @@ describe("Get Tags", () => {
 
   // Authenticated post request
   it("should try to get the list of owners and all tags and succeed", async () => {
-    let res = await request(app)
-      .get("/template/tag");
+    let res = await request(app).get("/template/tag");
     expect(res.status).toEqual(200);
     expect(res.body).toHaveProperty("ownedTags");
     expect(res.body).toHaveProperty("allTags");
@@ -601,7 +578,7 @@ describe("Get Tags", () => {
   });
 
   afterAll(async () => {
-    for (let id of idsToDelete){
+    for (let id of idsToDelete) {
       await request(app).delete(`/template/${id}`);
     }
   });

--- a/private-templates-service/adaptivecards-templating-service/src/tests_helper/db_t_definition.ts
+++ b/private-templates-service/adaptivecards-templating-service/src/tests_helper/db_t_definition.ts
@@ -35,6 +35,9 @@ function autoCompleteTemplateInstanceModel(instance: ITemplateInstance): void {
   if (!instance.publishedAt) {
     instance.publishedAt = undefined;
   }
+  if (!instance.data) {
+    instance.data = [];
+  }
 }
 function autoCompleteTemplateModel(template: ITemplate): void {
   if (!template.tags) {
@@ -150,7 +153,14 @@ export function testDB(db: StorageProvider) {
   });
 
   it("Completely filled: create & save user successfully", async () => {
-    const validUser: IUser = { firstName: "John", lastName: "Travolta", authIssuer: "Microsoft Oauth2", authId: "51201", org: ["Microsoft"], team: ["Bing"] };
+    const validUser: IUser = {
+      firstName: "John",
+      lastName: "Travolta",
+      authIssuer: "Microsoft Oauth2",
+      authId: "51201",
+      org: ["Microsoft"],
+      team: ["Bing"]
+    };
     await insertAndValidateUser(db, validUser);
   });
 
@@ -160,7 +170,7 @@ export function testDB(db: StorageProvider) {
   });
 
   it("Completely filled:create & save template successfully", async () => {
-    const validTemplateInstance: ITemplateInstance = { json: '"key":"value"', version: "1.0" };
+    const validTemplateInstance: ITemplateInstance = { json: JSON.parse('{"key":"value"}'), version: "1.0" };
     const validTemplate: ITemplate = {
       name: "validTemplate",
       instances: [validTemplateInstance],

--- a/private-templates-service/adaptivecards-templating-service/src/util/mongoutils/mongoutils.ts
+++ b/private-templates-service/adaptivecards-templating-service/src/util/mongoutils/mongoutils.ts
@@ -1,4 +1,5 @@
 import mongoose, { Document, Schema, Connection, Model } from "mongoose";
+import { ITemplateModel, ITemplateInstanceModel } from "../../models/mongo/TemplateModel";
 
 export module MongoUtils {
   export function getCollection<T extends Document>(db: Connection, collection: string, schema: Schema): Model<T> {
@@ -15,5 +16,38 @@ export module MongoUtils {
       }
     }
     return result;
+  }
+
+  export function restoreJSONTypeOfTemplate(templateModels: ITemplateModel[]): ITemplateModel[] {
+    return templateModels.map(template => {
+      template.instances = template.instances.map(instance => {
+        instance.json = MongoUtils.stringToJSON(Object.assign(instance.json) as string);
+        if (instance.data) {
+          instance.data = MongoUtils.stringArrayToJSONArray(Object.assign(instance.data) as string[]);
+        }
+        return instance;
+      });
+      return template;
+    });
+  }
+
+  export function jsonToString(obj: JSON): string {
+    return JSON.stringify(obj);
+  }
+
+  export function jsonArrayToString(obj: JSON[]): string[] {
+    return obj.map(j => {
+      return jsonToString(j);
+    });
+  }
+
+  export function stringToJSON(obj: string): JSON {
+    return JSON.parse(obj);
+  }
+
+  export function stringArrayToJSONArray(obj: string[]): JSON[] {
+    return obj.map(j => {
+      return stringToJSON(j);
+    });
   }
 }

--- a/private-templates-service/adaptivecards-templating-service/src/util/templateutils.ts
+++ b/private-templates-service/adaptivecards-templating-service/src/util/templateutils.ts
@@ -2,12 +2,12 @@ import { ITemplate, ITemplateInstance } from "../models/models";
 
 /**
  * @function
- * Updates passed ITemplate object to only have the latest version instance. 
- * @param template 
+ * Updates passed ITemplate object to only have the latest version instance.
+ * @param template
  */
-export function updateTemplateToLatestInstance(template : ITemplate) {
-  if (!template.instances || template.instances.length === 0) return template; 
-  let latestInstance : ITemplateInstance[] = [getMostRecentVersion(template)!];
+export function updateTemplateToLatestInstance(template: ITemplate) {
+  if (!template.instances || template.instances.length === 0) return template;
+  let latestInstance: ITemplateInstance[] = [getMostRecentVersion(template)!];
   template.instances = latestInstance;
 }
 
@@ -18,9 +18,9 @@ export function updateTemplateToLatestInstance(template : ITemplate) {
  * @param template
  */
 export function removeMostRecentTemplate(template: ITemplate): ITemplate {
-  if (!template.instances || template.instances.length === 0) return template; 
-  let lastVersion : ITemplateInstance = getMostRecentVersion(template)!;
-  let templateInstances = []
+  if (!template.instances || template.instances.length === 0) return template;
+  let lastVersion: ITemplateInstance = getMostRecentVersion(template)!;
+  let templateInstances = [];
   for (let instance of template.instances) {
     if (instance.version !== lastVersion.version) templateInstances.push(instance);
   }
@@ -32,12 +32,12 @@ export function removeMostRecentTemplate(template: ITemplate): ITemplate {
 /**
  * @function
  * Returns the most recent template version/instance given the template.
- * @param template 
+ * @param template
  */
 export function getMostRecentVersion(template: ITemplate): ITemplateInstance | undefined {
   if (!template.instances || template.instances.length === 0) return undefined;
   let latestInstance = template.instances[0];
-  for (let instance of template.instances){
+  for (let instance of template.instances) {
     if (compareVersion(instance.version, latestInstance.version)) {
       latestInstance = instance;
     }
@@ -48,12 +48,12 @@ export function getMostRecentVersion(template: ITemplate): ITemplateInstance | u
 /**
  * @function
  * Returns the specified template version/instance.
- * @param template 
- * @param version 
+ * @param template
+ * @param version
  */
 export function getTemplateVersion(template: ITemplate, version: string): ITemplateInstance | undefined {
   if (!template.instances || template.instances.length === 0) return undefined;
-  for (let instance of template.instances){
+  for (let instance of template.instances) {
     if (version === instance.version) {
       return instance;
     }
@@ -63,33 +63,17 @@ export function getTemplateVersion(template: ITemplate, version: string): ITempl
 
 /**
  * @function
- * Returns true if a's version is greater than b, returns false if the same 
+ * Returns true if a's version is greater than b, returns false if the same
  */
 export function compareVersion(a: string, b: string): boolean {
-  let v1 = a.split('.');
-  let v2 = b.split('.');
+  let v1 = a.split(".");
+  let v2 = b.split(".");
   let length = Math.min(v1.length, v2.length);
-  for (let i = 0; i < length; i++){
+  for (let i = 0; i < length; i++) {
     let v1i = parseInt(v1[i], 10);
     let v2i = parseInt(v2[i], 10);
     if (v1i > v2i) return true;
     if (v1i < v2i) return false;
   }
-  return (v1.length == v2.length)? false : v1.length > v2.length;
-}
-
-export function stringifyJSONArray(list: JSON[]): string[] {
-  let result = [];
-  for (let item of list) {
-    result.push(JSON.stringify(item));
-  }
-  return result;
-}
-
-export function JSONStringArray(list: string[]): JSON[] {
-  let result = [];
-  for (let item of list) {
-    result.push(JSON.parse(item));
-  }
-  return result;
+  return v1.length == v2.length ? false : v1.length > v2.length;
 }


### PR DESCRIPTION
[ACB-33792](https://microsoftgarage.visualstudio.com/Intern%20GitHub/_workitems/edit/33792)
In this PR I've addressed an issue of saving template JSON as string to db while retrieving it as JSON. The reason for not storing template as JSON in db is due to Mongo Limitation of not allowing **$** and **.** in key names.

What has been done to solve it:
1) **TemplateInstanceModel** was updated to have **json** and **data** in JSON format
2) Before saving it to db, both json and data fields will be converted to String
3) When retrieving templates from the db, json and data fields will be converted back to JSON format
In the postman when retrieving the template:

![image](https://user-images.githubusercontent.com/21356912/75284707-27be1380-57ca-11ea-9eec-d83981a6f28b.png)
