### PR TITLE
Change run build:stage to run build:staging

### DIFF
--- a/.github/workflows/azure-stage.yml
+++ b/.github/workflows/azure-stage.yml
@@ -71,7 +71,7 @@ jobs:
                   # Build and test the project, then
                   # deploy to Azure Web App.
                   cd private-templates-service/client
-                  npm run build:stage --if-present
+                  npm run build:staging --if-present
                   cd ../adaptivecards-templating-service
                   npm link
                   cd ../server


### PR DESCRIPTION
Stage deployment did not work because we used the word "stage" instead of "staging". 