### PR TITLE
Fix Publish, Timestamp, and Card Formatting

### DIFF
--- a/private-templates-service/client/src/Services/ProcessTemplate.ts
+++ b/private-templates-service/client/src/Services/ProcessTemplate.ts
@@ -1,7 +1,0 @@
-export const processTemplate = (template: string) => {
-  let parsedTemplate = template.replace(/(\\"(.*?)\\")/g, '"$2"');
-  parsedTemplate = parsedTemplate.substr(1, parsedTemplate.length - 2);
-  return parsedTemplate;
-}
-
-export default processTemplate;

--- a/private-templates-service/client/src/components/AdaptiveCardPanel/styled.tsx
+++ b/private-templates-service/client/src/components/AdaptiveCardPanel/styled.tsx
@@ -4,7 +4,8 @@ import { COLORS } from '../../globalStyles';
 export const Container = styled.div`
   display: flex;
   flex-direction: column;
-  margin-right: 20px;
+  margin: 0 24px 24px 0;
+  align-self: flex-start;
 
   background: white;
   border-radius: 5px;

--- a/private-templates-service/client/src/components/AdaptiveCardPanel/styled.tsx
+++ b/private-templates-service/client/src/components/AdaptiveCardPanel/styled.tsx
@@ -5,7 +5,6 @@ export const Container = styled.div`
   display: flex;
   flex-direction: column;
   margin: 0 24px 24px 0;
-  align-self: flex-start;
 
   background: white;
   border-radius: 5px;

--- a/private-templates-service/client/src/components/Common/PublishModal/PublishModal.tsx
+++ b/private-templates-service/client/src/components/Common/PublishModal/PublishModal.tsx
@@ -13,7 +13,6 @@ import { updateTemplate } from '../../../store/currentTemplate/actions';
 
 // Components
 import AdaptiveCard from '../AdaptiveCard';
-import processTemplate from '../../../Services/ProcessTemplate';
 
 // Styles
 import {
@@ -58,7 +57,7 @@ class PublishModal extends React.Component<Props> {
     } = this.props.template;
     if (id && name && instances && instances.length === 1 && instances[0].json) {
       const template = instances[0].json;
-      const parsedTemplate = processTemplate(template);
+      const parsedTemplate = JSON.stringify(template);
       this.props.publishTemplate(id, parsedTemplate, "", name);
       this.props.toggleModal();
     }
@@ -75,7 +74,7 @@ class PublishModal extends React.Component<Props> {
           <CenterPanelWrapper>
             <CenterPanelLeft>
               <AdaptiveCardPanel>
-                <AdaptiveCard cardtemplate={template} templateVersion={this.props.templateVersion}/>
+                <AdaptiveCard cardtemplate={template} templateVersion={this.props.templateVersion} />
               </AdaptiveCardPanel>
               <SemiBoldText>
                 Notified

--- a/private-templates-service/client/src/components/Dashboard/PreviewModal/TemplateInfo/TemplateInfo.tsx
+++ b/private-templates-service/client/src/components/Dashboard/PreviewModal/TemplateInfo/TemplateInfo.tsx
@@ -87,14 +87,14 @@ class TemplateInfo extends React.Component<Props, State> {
   versionList = (instances: TemplateInstance[] | undefined): IDropdownOption[] => {
     if (!instances) return [];
     let options: IDropdownOption[] = [];
-    for (let instance of instances){
+    for (let instance of instances) {
       if (!instance.version) continue;
-      options.push({key: instance.version, text: `Version ${instance.version}`});
+      options.push({ key: instance.version, text: `Version ${instance.version}` });
     }
     return options;
   }
 
-  onVersionChange = (event: React.FormEvent<HTMLDivElement>, option?:IDropdownOption) => {
+  onVersionChange = (event: React.FormEvent<HTMLDivElement>, option?: IDropdownOption) => {
     if (!option) return;
     let version = option.key.toString();
     this.setState({ version: version });
@@ -105,30 +105,37 @@ class TemplateInfo extends React.Component<Props, State> {
     const {
       isLive,
       tags,
-      createdAt, 
+      createdAt,
       instances,
     } = this.props.template;
     const { onClose } = this.props;
+
+    let createdAtParsed = "";
+
+    if (createdAt) {
+      const createdAtDate = new Date(createdAt);
+      createdAtParsed = createdAtDate.toLocaleString();
+    }
 
     return (
       <OuterWrapper>
         <HeaderWrapper>
           <TopRowWrapper>
             <TitleWrapper>
-            <Title>
+              <Title>
                 <StyledVersionDropdown
-                  placeholder = {`Version ${this.state.version}`}
-                  options = {this.versionList(instances)}
-                  onChange = {this.onVersionChange}
-                  theme = {THEME.LIGHT}
-                  styles = {DropdownStyles}
+                  placeholder={`Version ${this.state.version}`}
+                  options={this.versionList(instances)}
+                  onChange={this.onVersionChange}
+                  theme={THEME.LIGHT}
+                  styles={DropdownStyles}
                 />
               </Title>
               <StatusIndicator isPublished={isLive} />
               <Status>{isLive ? 'Published' : 'Draft'}</Status>
             </TitleWrapper>
             <TimeStamp>
-              Created {createdAt}
+              Created {createdAtParsed}
             </TimeStamp>
             <ActionButton iconProps={{ iconName: 'ChromeClose' }} onClick={onClose} >Close</ActionButton>
           </TopRowWrapper>
@@ -164,7 +171,7 @@ class TemplateInfo extends React.Component<Props, State> {
             </CardBody>
           </Card>
         </MainContentWrapper>
-        {this.state.isPublishOpen && <PublishModal toggleModal={this.toggleModal} template={this.props.template} templateVersion={this.state.version}/>}
+        {this.state.isPublishOpen && <PublishModal toggleModal={this.toggleModal} template={this.props.template} templateVersion={this.state.version} />}
       </OuterWrapper>
     );
   }

--- a/private-templates-service/client/src/components/Gallery/styled.tsx
+++ b/private-templates-service/client/src/components/Gallery/styled.tsx
@@ -5,6 +5,6 @@ export const Container = styled.div`
 	flex-direction: row;
 	justify-content: left;
 	flex-wrap: wrap;
-
+  align-items: flex-start;
 	margin-top: 10px;
 `;


### PR DESCRIPTION
## Description
This short PR fixes three things:
1. Previously, publish was not working because the definition of template.json changed from a string to a JSON object. The fix was to stringify before passing into the function
2. Date timestamp was previously ISO time, its now parsed to a more human readable time
3. Cards are formatted to have some additional spacing, minor change. 