### PR TITLE
Update backend to return template versions sorted by most recent version

### DIFF
--- a/private-templates-service/adaptivecards-templating-service/src/TemplateServiceClient.ts
+++ b/private-templates-service/adaptivecards-templating-service/src/TemplateServiceClient.ts
@@ -1,12 +1,11 @@
 import { ClientOptions } from "./IClientOptions";
 import express, { Request, Response, NextFunction, Router } from "express";
-import { check, validationResult } from "express-validator";
 import { AuthenticationProvider } from ".";
 import { TemplateError, ApiError, ServiceErrorMessage } from "./models/errorModels";
 import { StorageProvider } from ".";
 import { ITemplate, JSONResponse, ITemplateInstance, IUser } from ".";
 import { SortBy, SortOrder, TemplatePreview, TemplateState, TemplateInstancePreview, UserPreview, TagList } from "./models/models";
-import { updateTemplateToLatestInstance, removeMostRecentTemplate, getTemplateVersion, isValidJSONString } from "./util/templateutils";
+import { updateTemplateToLatestInstance, removeMostRecentTemplate, getTemplateVersion, isValidJSONString, sortTemplateByVersion } from "./util/templateutils";
 
 export class TemplateServiceClient {
   private storageProvider: StorageProvider;
@@ -698,7 +697,7 @@ export class TemplateServiceClient {
         // Update hit counter for template
         this._incrementTemplateHits(templateId, templates![0], version);
       }
-
+      sortTemplateByVersion(templates![0]);
       if (!version) return { success: true, result: templates };
     }
 

--- a/private-templates-service/adaptivecards-templating-service/src/TemplateServiceClient.ts
+++ b/private-templates-service/adaptivecards-templating-service/src/TemplateServiceClient.ts
@@ -1089,7 +1089,6 @@ export class TemplateServiceClient {
 
     router.post("/:id*?", async (req: Request, res: Response, _next: NextFunction) => {
       if (req.body.template !== undefined && (!(req.body.template instanceof Object) || !isValidJSONString(JSON.stringify(req.body.template)))) {
-        console.log(req.body.template);
         const err = new TemplateError(ApiError.InvalidTemplate, `Template must be valid JSON.`);
         return res.status(400).json({ error: err });
       }

--- a/private-templates-service/adaptivecards-templating-service/src/util/templateutils.ts
+++ b/private-templates-service/adaptivecards-templating-service/src/util/templateutils.ts
@@ -80,6 +80,24 @@ export function compareVersion(a: string, b: string): boolean {
 
 /**
  * @function
+ */
+export function compareTemplateVersions(a: ITemplateInstance, b: ITemplateInstance): number {
+  return compareVersion(a.version, b.version)? -1 : 1;
+}
+
+/**
+ * @function
+ * Sort template by most recent version
+ * @param template 
+ */
+export function sortTemplateByVersion(template: ITemplate) {
+  if (!template.instances) return;
+  let instances: ITemplateInstance[] = template.instances.sort(compareTemplateVersions);
+  template.instances = instances;
+}
+
+/**
+ * @function
  * @param input 
  */
 export function isValidJSONString(input: string) {


### PR DESCRIPTION
`GET /template/{id}` now returns all template versions sorted by most recent. 