### PR TITLE
Update client to use client flag to track template hits

### DIFF
--- a/private-templates-service/adaptivecards-templating-client/swagger.yaml
+++ b/private-templates-service/adaptivecards-templating-client/swagger.yaml
@@ -51,6 +51,10 @@ paths:
           name: isPublished
           type: boolean
           description: Query based on if template is published
+        - name: isClient
+          in: query
+          type: boolean
+          description: If true, ignores updating hits on template
         - in: query
           name: name
           type: string
@@ -129,6 +133,10 @@ paths:
           in: query
           type: boolean
           description: Query based on if template is published
+        - name: isClient
+          in: query
+          type: boolean
+          description: If true, ignores updating hits on template
         - name: version
           in: query
           type: string
@@ -417,8 +425,6 @@ definitions:
         items: 
           type: object
           format: JSON
-      isClient: 
-        type: boolean
   UserList:
     type: object
     properties:

--- a/private-templates-service/adaptivecards-templating-client/swagger.yaml
+++ b/private-templates-service/adaptivecards-templating-client/swagger.yaml
@@ -389,7 +389,8 @@ definitions:
       data: 
         type: array
         items: 
-          type: string
+          type: object
+          format: JSON
       updatedAt:
         type: string
         format: Date
@@ -509,7 +510,7 @@ definitions:
       data: 
         type: array
         items:  
-          type: string
+          type: object
           format: JSON
   TemplatePreviewUser: 
     type: object

--- a/private-templates-service/adaptivecards-templating-client/swagger.yaml
+++ b/private-templates-service/adaptivecards-templating-client/swagger.yaml
@@ -417,6 +417,8 @@ definitions:
         items: 
           type: object
           format: JSON
+      isClient: 
+        type: boolean
   UserList:
     type: object
     properties:

--- a/private-templates-service/adaptivecards-templating-client/typescript/api.ts
+++ b/private-templates-service/adaptivecards-templating-client/typescript/api.ts
@@ -185,7 +185,6 @@ export class PostedTemplate {
     'isPublished'?: boolean;
     'tags'?: Array<string>;
     'data'?: Array<any>;
-    'isClient'?: boolean;
 
     static discriminator: string | undefined = undefined;
 
@@ -229,11 +228,6 @@ export class PostedTemplate {
             "name": "data",
             "baseName": "data",
             "type": "Array<any>"
-        },
-        {
-            "name": "isClient",
-            "baseName": "isClient",
-            "type": "boolean"
         }    ];
 
     static getAttributeTypeMap() {
@@ -849,6 +843,7 @@ export class TemplateApi {
      * Returns the latest version of all public templates and owned templates
      * @summary Find all templates
      * @param isPublished Query based on if template is published
+     * @param isClient If true, ignores updating hits on template
      * @param name Name of template to query for
      * @param version Version of template
      * @param owned Display only the templates owned by the user
@@ -857,7 +852,7 @@ export class TemplateApi {
      * @param tags List of tags to filter templates by
      * @param {*} [options] Override http request options.
      */
-    public allTemplates (isPublished?: boolean, name?: string, version?: string, owned?: boolean, sortBy?: 'alphabetical' | 'dateCreated' | 'dateUpdated', sortOrder?: 'ascending' | 'descending', tags?: string, options: any = {}) : Promise<{ response: http.IncomingMessage; body: TemplateList;  }> {
+    public allTemplates (isPublished?: boolean, isClient?: boolean, name?: string, version?: string, owned?: boolean, sortBy?: 'alphabetical' | 'dateCreated' | 'dateUpdated', sortOrder?: 'ascending' | 'descending', tags?: string, options: any = {}) : Promise<{ response: http.IncomingMessage; body: TemplateList;  }> {
         const localVarPath = this.basePath + '/template';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
@@ -865,6 +860,10 @@ export class TemplateApi {
 
         if (isPublished !== undefined) {
             localVarQueryParameters['isPublished'] = ObjectSerializer.serialize(isPublished, "boolean");
+        }
+
+        if (isClient !== undefined) {
+            localVarQueryParameters['isClient'] = ObjectSerializer.serialize(isClient, "boolean");
         }
 
         if (name !== undefined) {
@@ -1164,10 +1163,11 @@ export class TemplateApi {
      * @summary Find template by id
      * @param templateId ID of template to return
      * @param isPublished Query based on if template is published
+     * @param isClient If true, ignores updating hits on template
      * @param version Version of template to return
      * @param {*} [options] Override http request options.
      */
-    public templateById (templateId: string, isPublished?: boolean, version?: string, options: any = {}) : Promise<{ response: http.IncomingMessage; body: TemplateList;  }> {
+    public templateById (templateId: string, isPublished?: boolean, isClient?: boolean, version?: string, options: any = {}) : Promise<{ response: http.IncomingMessage; body: TemplateList;  }> {
         const localVarPath = this.basePath + '/template/{templateId}'
             .replace('{' + 'templateId' + '}', encodeURIComponent(String(templateId)));
         let localVarQueryParameters: any = {};
@@ -1181,6 +1181,10 @@ export class TemplateApi {
 
         if (isPublished !== undefined) {
             localVarQueryParameters['isPublished'] = ObjectSerializer.serialize(isPublished, "boolean");
+        }
+
+        if (isClient !== undefined) {
+            localVarQueryParameters['isClient'] = ObjectSerializer.serialize(isClient, "boolean");
         }
 
         if (version !== undefined) {

--- a/private-templates-service/adaptivecards-templating-client/typescript/api.ts
+++ b/private-templates-service/adaptivecards-templating-client/typescript/api.ts
@@ -454,7 +454,7 @@ export class TemplateInstance {
     'state'?: TemplateInstance.StateEnum;
     'isShareable'?: boolean;
     'numHits'?: number;
-    'data'?: Array<string>;
+    'data'?: Array<any>;
     'updatedAt'?: string;
     'createdAt'?: string;
 
@@ -499,7 +499,7 @@ export class TemplateInstance {
         {
             "name": "data",
             "baseName": "data",
-            "type": "Array<string>"
+            "type": "Array<any>"
         },
         {
             "name": "updatedAt",
@@ -562,7 +562,7 @@ export class TemplatePreviewInstance {
     'version'?: string;
     'json'?: string;
     'state'?: string;
-    'data'?: Array<string>;
+    'data'?: Array<any>;
 
     static discriminator: string | undefined = undefined;
 
@@ -585,7 +585,7 @@ export class TemplatePreviewInstance {
         {
             "name": "data",
             "baseName": "data",
-            "type": "Array<string>"
+            "type": "Array<any>"
         }    ];
 
     static getAttributeTypeMap() {

--- a/private-templates-service/adaptivecards-templating-client/typescript/api.ts
+++ b/private-templates-service/adaptivecards-templating-client/typescript/api.ts
@@ -184,7 +184,8 @@ export class PostedTemplate {
     'isShareable'?: boolean;
     'isPublished'?: boolean;
     'tags'?: Array<string>;
-    'data'?: Array<string>;
+    'data'?: Array<any>;
+    'isClient'?: boolean;
 
     static discriminator: string | undefined = undefined;
 
@@ -227,7 +228,12 @@ export class PostedTemplate {
         {
             "name": "data",
             "baseName": "data",
-            "type": "Array<string>"
+            "type": "Array<any>"
+        },
+        {
+            "name": "isClient",
+            "baseName": "isClient",
+            "type": "boolean"
         }    ];
 
     static getAttributeTypeMap() {

--- a/private-templates-service/adaptivecards-templating-service/src/TemplateServiceClient.ts
+++ b/private-templates-service/adaptivecards-templating-service/src/TemplateServiceClient.ts
@@ -1003,7 +1003,8 @@ export class TemplateServiceClient {
 
       let isPublished: boolean | undefined = req.query.isPublished ? req.query.isPublished === "true" || req.query.isPublished === "True" : undefined;
       let owned: boolean | undefined = req.query.owned ? req.query.owned === "true" || req.query.owned === "True" : undefined;
-      let isClient: boolean = req.body.isClient;
+      let isClient: boolean | undefined = req.query.isClient ? req.query.isClient === "true" || req.query.isClient === "True" : undefined;
+      
       if (!req.is("application/json")) {
         isClient = req.body.isClient === "true" || req.body.isClient === "True";
       }
@@ -1061,10 +1062,7 @@ export class TemplateServiceClient {
     });
 
     router.get("/:id?", (req: Request, res: Response, _next: NextFunction) => {
-      let isClient: boolean = req.body.isClient;
-      if (!req.is("application/json")) {
-        isClient = req.body.isClient === "true" || req.body.isClient === "True";
-      }
+      let isClient: boolean | undefined = req.query.isClient ? req.query.isClient === "true" || req.query.isClient === "True" : undefined;
 
       this.getTemplates(req.params.id, undefined, undefined, req.query.version, undefined, undefined, undefined, undefined, isClient).then(
         response => {

--- a/private-templates-service/adaptivecards-templating-service/src/TemplateServiceClient.ts
+++ b/private-templates-service/adaptivecards-templating-service/src/TemplateServiceClient.ts
@@ -1001,12 +1001,12 @@ export class TemplateServiceClient {
         res.status(400).json({ error: err });
       }
 
-      let isPublished: boolean | undefined = req.query.isPublished ? req.query.isPublished === "true" || req.query.isPublished === "True" : undefined;
-      let owned: boolean | undefined = req.query.owned ? req.query.owned === "true" || req.query.owned === "True" : undefined;
-      let isClient: boolean | undefined = req.query.isClient ? req.query.isClient === "true" || req.query.isClient === "True" : undefined;
+      let isPublished: boolean | undefined = req.query.isPublished ? req.query.isPublished.toLowerCase() === "true" : undefined;
+      let owned: boolean | undefined = req.query.owned ? req.query.owned.toLowerCase() === "true" : undefined;
+      let isClient: boolean | undefined = req.query.isClient ? req.query.isClient.toLowerCase() === "true" : undefined;
       
       if (!req.is("application/json")) {
-        isClient = req.body.isClient === "true" || req.body.isClient === "True";
+        isClient = req.body.isClient.toLowerCase() === "true";
       }
 
       let tagList: string[] = req.query.tags? req.query.tags.split(",") : undefined;
@@ -1062,7 +1062,7 @@ export class TemplateServiceClient {
     });
 
     router.get("/:id?", (req: Request, res: Response, _next: NextFunction) => {
-      let isClient: boolean | undefined = req.query.isClient ? req.query.isClient === "true" || req.query.isClient === "True" : undefined;
+      let isClient: boolean | undefined = req.query.isClient ? req.query.isClient.toLowerCase() === "true" : undefined;
 
       this.getTemplates(req.params.id, undefined, undefined, req.query.version, undefined, undefined, undefined, undefined, isClient).then(
         response => {
@@ -1094,8 +1094,8 @@ export class TemplateServiceClient {
       let isPublished: boolean = req.body.isPublished;
       let isShareable: boolean = req.body.isShareable;
       if (!req.is("application/json")) {
-        isPublished = req.body.isPublished === "true" || req.body.isPublished === "True";
-        isShareable = req.body.isShareable === "true" || req.body.isShareable === "True";
+        isPublished = req.body.isPublished.toLowerCase() === "true";
+        isShareable = req.body.isShareable.toLowerCase() === "true";
       }
 
       let tags: string[] | string = req.body.tags;

--- a/private-templates-service/adaptivecards-templating-service/src/models/mongo/TemplateModel.ts
+++ b/private-templates-service/adaptivecards-templating-service/src/models/mongo/TemplateModel.ts
@@ -18,7 +18,7 @@ export const TemplateInstanceSchema: Schema = new Schema(
     publishedAt: { type: Date, default: null },
     state: { type: String, default: TemplateState.draft },
     isShareable: { type: Boolean, default: false },
-    hits: { type: Number, default: 0 },
+    numHits: { type: Number, default: 0 },
     data: { type: [String], default: [], set: MongoUtils.jsonArrayToString }
   },
   {

--- a/private-templates-service/client/src/store/currentTemplate/actions.ts
+++ b/private-templates-service/client/src/store/currentTemplate/actions.ts
@@ -154,7 +154,7 @@ export function getTemplate(templateID: string) {
     api.setApiKey(0, "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6IkhsQzBSMTJza3hOWjFXUXdtak9GXzZ0X3RERSJ9.eyJhdWQiOiI4NjMxY2E0ZS1hMjVkLTQ5YWUtYmQ5OC1mZjNlMWRkZDQ0MTgiLCJpc3MiOiJodHRwczovL2xvZ2luLm1pY3Jvc29mdG9ubGluZS5jb20vNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3YyLjAiLCJpYXQiOjE1ODEzNjA2MTgsIm5iZiI6MTU4MTM2MDYxOCwiZXhwIjoxNTgxMzY0NTE4LCJhaW8iOiI0Mk5nWUdDVzk3Qm1NamRrY3pQK1pLSGZMeFlPQUE9PSIsImF6cCI6Ijg2MzFjYTRlLWEyNWQtNDlhZS1iZDk4LWZmM2UxZGRkNDQxOCIsImF6cGFjciI6IjEiLCJvaWQiOiI4YWRiZWRhNi00ZDdkLTQ1N2ItOTNkZC1jMTVmMWE1Y2NiMzEiLCJzdWIiOiI4YWRiZWRhNi00ZDdkLTQ1N2ItOTNkZC1jMTVmMWE1Y2NiMzEiLCJ0aWQiOiI3MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDciLCJ1dGkiOiJ6SDlkcHVQNnprcUJidC1MUnVGYkFBIiwidmVyIjoiMi4wIn0.WhdvkqeJymW-Ayeht6tafd8Z1muoMnyPhKoYq6KGrHdv6psfYQtmK0P0-TA5_zgOOHNNJvpVqH2LPnZTbpK4qgKLByR9umELHgD2FW9v5Djg1NAKqmQEGg_-Th__SGE3L9_WI58Wh0_Toh3f7fpLDzNBiC5iYDdGSaTilwxaYMGbXnJO2Y6Tow83GQATKGA3B27Xz2iBO9UFmEy9rte4DyLUAEIE6SCKwg-3YuD0zKfpgyd-lvhZZr37HeE9Y6hyOm_M4b_jwWI7oK0uZASuQer83W5jsSZNtiXg_T0euXJcvI9lL6R4oJDI_N6Y42RdDioIwX6FzOA4vRzTySZjBw");
 
     try {
-      api.templateById(templateID).then((resp: any) => {
+      api.templateById(templateID, undefined, true).then((resp: any) => {
         if (resp.body.templates.length === 1) {
           const templateObject = resp.body.templates[0];
           return dispatch(

--- a/private-templates-service/client/src/store/search/actions.ts
+++ b/private-templates-service/client/src/store/search/actions.ts
@@ -40,7 +40,7 @@ export function querySearch(searchByTemplateName: string): (dispatch: any) => vo
     // TODO: dynamiclly fetch bearer token
     api.setApiKey(0, "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6IkhsQzBSMTJza3hOWjFXUXdtak9GXzZ0X3RERSJ9.eyJhdWQiOiI0ODAzZjY2YS0xMzZkLTQxNTUtYTUxZS02ZDk4NDAwZDU1MDYiLCJpc3MiOiJodHRwczovL2xvZ2luLm1pY3Jvc29mdG9ubGluZS5jb20vNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3YyLjAiLCJpYXQiOjE1ODE0NzAxMDYsIm5iZiI6MTU4MTQ3MDEwNiwiZXhwIjoxNTgxNDc0MDA2LCJhaW8iOiI0Mk5nWUtqNDUzd3dLdjFQbTE3KysyMEsxNnd1QVFBPSIsImF6cCI6IjQ4MDNmNjZhLTEzNmQtNDE1NS1hNTFlLTZkOTg0MDBkNTUwNiIsImF6cGFjciI6IjEiLCJvaWQiOiI4Yzg1ZjgwNi03MDA1LTRlY2QtOGYxZS1kMWY3ODRmNThiOWMiLCJzdWIiOiI4Yzg1ZjgwNi03MDA1LTRlY2QtOGYxZS1kMWY3ODRmNThiOWMiLCJ0aWQiOiI3MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDciLCJ1dGkiOiJxcjRDdVI4LUlFdWZ4eUE0Q3VZZkFBIiwidmVyIjoiMi4wIn0.MsCIvnouCP30Oto72KaFKfew7kA5bfvkrs1P9RJhw_qYFPNFR4cJ-m3q4oEVc0Iy0fjml6qiUatPF6cQJW-dy8gghtZaUaju_oDd4kCpeRZEZt2JO9ew_n0F3o8Qfsd8QrlkVPxmCL6iL0ih3jSYHqzvvf7eMR4RyfwkX_o-j5jZkOCfTqDt2lh27LrLDPiyfQIwvALiHoX7xDTe7R6-1JRfrqa6MgHchtkeJex0pDdU8LXDUVJlR1KY62tdl7vNxY8z9KoZrSV4Kv1wZpMwCi5tfHt6cfYU5-8pHVbrydyzdfPqAnWgUtgcBDCR2i3Dg-z_L0RE8Ao6sPrr742KRA");
 
-    return api.allTemplates(undefined, searchByTemplateName)
+    return api.allTemplates(undefined, true, searchByTemplateName)
       .then(response => {
         if (response.response && response.response.statusCode === 200) {
           dispatch(querySearchSuccess(response.body, searchByTemplateName));

--- a/private-templates-service/client/src/store/templates/actions.ts
+++ b/private-templates-service/client/src/store/templates/actions.ts
@@ -28,7 +28,7 @@ export function getAllTemplates() {
     let api = new TemplateApi()
     // TODO dynamically fetch bearer token
     api.setApiKey(0, "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6IkhsQzBSMTJza3hOWjFXUXdtak9GXzZ0X3RERSJ9.eyJhdWQiOiI0ODAzZjY2YS0xMzZkLTQxNTUtYTUxZS02ZDk4NDAwZDU1MDYiLCJpc3MiOiJodHRwczovL2xvZ2luLm1pY3Jvc29mdG9ubGluZS5jb20vNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3YyLjAiLCJpYXQiOjE1ODE0NzAxMDYsIm5iZiI6MTU4MTQ3MDEwNiwiZXhwIjoxNTgxNDc0MDA2LCJhaW8iOiI0Mk5nWUtqNDUzd3dLdjFQbTE3KysyMEsxNnd1QVFBPSIsImF6cCI6IjQ4MDNmNjZhLTEzNmQtNDE1NS1hNTFlLTZkOTg0MDBkNTUwNiIsImF6cGFjciI6IjEiLCJvaWQiOiI4Yzg1ZjgwNi03MDA1LTRlY2QtOGYxZS1kMWY3ODRmNThiOWMiLCJzdWIiOiI4Yzg1ZjgwNi03MDA1LTRlY2QtOGYxZS1kMWY3ODRmNThiOWMiLCJ0aWQiOiI3MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDciLCJ1dGkiOiJxcjRDdVI4LUlFdWZ4eUE0Q3VZZkFBIiwidmVyIjoiMi4wIn0.MsCIvnouCP30Oto72KaFKfew7kA5bfvkrs1P9RJhw_qYFPNFR4cJ-m3q4oEVc0Iy0fjml6qiUatPF6cQJW-dy8gghtZaUaju_oDd4kCpeRZEZt2JO9ew_n0F3o8Qfsd8QrlkVPxmCL6iL0ih3jSYHqzvvf7eMR4RyfwkX_o-j5jZkOCfTqDt2lh27LrLDPiyfQIwvALiHoX7xDTe7R6-1JRfrqa6MgHchtkeJex0pDdU8LXDUVJlR1KY62tdl7vNxY8z9KoZrSV4Kv1wZpMwCi5tfHt6cfYU5-8pHVbrydyzdfPqAnWgUtgcBDCR2i3Dg-z_L0RE8Ao6sPrr742KRA");
-    return api.allTemplates()
+    return api.allTemplates(undefined, true)
       .then(response => {
         if (response.response.statusCode && response.response.statusCode == 200) {
           dispatch(receiveAllTemplates(response.body))


### PR DESCRIPTION
This PR makes sure the client accessing template by id does not increase the number of hits on the template. 

**Changes**
- Fix mongo provider bug using hits instead of numHits field 
- Add client query param flag to client SDK definition + update client
- Fix client SDK data type to any (for JSON object) instead of string
 