### PR TITLE
Fix version bug in TemplateInfo.tsx

### DIFF
--- a/private-templates-service/client/src/components/Dashboard/PreviewModal/PreviewModal.tsx
+++ b/private-templates-service/client/src/components/Dashboard/PreviewModal/PreviewModal.tsx
@@ -56,10 +56,13 @@ class PreviewModal extends React.Component<Props, State> {
         this.props.show && this.props.template && this.props.template.name ? this.props.template.name : 'Dashboard',
         this.props.show && this.props.template && this.props.template.name ? this.props.template.name : 'Dashboard');
     }
+    if (prevProps.template !== this.props.template && this.props.template && this.props.template.instances
+      && this.props.template.instances[0] && this.props.template.instances[0].version) {
+      this.setState({ templateVersion: this.props.template.instances[0].version });
+    }
   }
 
   render() {
-
     const {
       show,
       isFetching,
@@ -70,7 +73,7 @@ class PreviewModal extends React.Component<Props, State> {
       <ModalBackdrop>
         <ModalWrapper>
           {template && !isFetching ?
-            <React.Fragment>
+            < React.Fragment >
               <ACPanel>
                 <ACWrapper>
                   <AdaptiveCard cardtemplate={template} templateVersion={this.state.templateVersion} />
@@ -83,7 +86,7 @@ class PreviewModal extends React.Component<Props, State> {
             : <CenteredSpinner size={SpinnerSize.large} />
           }
         </ModalWrapper>
-      </ModalBackdrop>
+      </ModalBackdrop >
     ) : null;
   }
 }

--- a/private-templates-service/client/src/components/Dashboard/PreviewModal/TemplateInfo/TemplateInfo.tsx
+++ b/private-templates-service/client/src/components/Dashboard/PreviewModal/TemplateInfo/TemplateInfo.tsx
@@ -75,10 +75,20 @@ interface State {
   version: string;
 }
 
+function getVersion(template: Template): string {
+  if (template.instances && template.instances[0] && template.instances[0].version) {
+    return template.instances[0].version;
+  }
+  return "1.0"
+
+}
+
 class TemplateInfo extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props);
-    this.state = { isPublishOpen: false, version: "1.0" }
+    const vers = getVersion(this.props.template);
+    this.state = { isPublishOpen: false, version: vers }
+
   }
 
   toggleModal = () => {
@@ -132,7 +142,7 @@ class TemplateInfo extends React.Component<Props, State> {
                   styles={DropdownStyles}
                 />
               </Title>
-              <StatusIndicator state={isLive? PostedTemplate.StateEnum.Live : PostedTemplate.StateEnum.Draft} />
+              <StatusIndicator state={isLive ? PostedTemplate.StateEnum.Live : PostedTemplate.StateEnum.Draft} />
               <Status>{isLive ? 'Published' : 'Draft'}</Status>
             </TitleWrapper>
             <TimeStamp>
@@ -172,7 +182,7 @@ class TemplateInfo extends React.Component<Props, State> {
             </CardBody>
           </Card>
           <RowWrapper>
-            <VersionCard template={this.props.template} templateVersion={this.state.version}/>
+            <VersionCard template={this.props.template} templateVersion={this.state.version} />
           </RowWrapper>
         </MainContentWrapper>
         {this.state.isPublishOpen && <PublishModal toggleModal={this.toggleModal} template={this.props.template} templateVersion={this.state.version} />}

--- a/private-templates-service/client/src/components/Dashboard/PreviewModal/TemplateInfo/TemplateInfo.tsx
+++ b/private-templates-service/client/src/components/Dashboard/PreviewModal/TemplateInfo/TemplateInfo.tsx
@@ -80,7 +80,6 @@ function getVersion(template: Template): string {
     return template.instances[0].version;
   }
   return "1.0"
-
 }
 
 class TemplateInfo extends React.Component<Props, State> {


### PR DESCRIPTION
Fixed bug in "Template Info" page. 

Before: It always displayed version 1.0 of the template, even though the dashboard displays the most recent version of the template.
![image](https://user-images.githubusercontent.com/40618774/75826575-a122ac80-5d5c-11ea-9c1d-fc6dbca3ac56.png)




After: It defaults to displaying the most recent version of the template in the "Template Info" page. 
![image](https://user-images.githubusercontent.com/40618774/75826502-7df7fd00-5d5c-11ea-815f-c351e7eb1df5.png)


