### PR TITLE
Create modal HOC to position modal closer to app root

### DIFF
--- a/private-templates-service/client/src/App.tsx
+++ b/private-templates-service/client/src/App.tsx
@@ -136,6 +136,7 @@ class App extends Component<Props, State> {
             </MainAppWrapper>
           </OuterAppWrapper>
         </Switch>
+        <div id="modal" />
       </Router >
     );
   }

--- a/private-templates-service/client/src/components/Common/PublishModal/PublishModal.tsx
+++ b/private-templates-service/client/src/components/Common/PublishModal/PublishModal.tsx
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 
 // Libraries
 import { TextField } from 'office-ui-fabric-react/lib/TextField';
-import { PrimaryButton, ThemeSettingName } from 'office-ui-fabric-react'
+import { PrimaryButton } from 'office-ui-fabric-react'
 import { SearchBox } from 'office-ui-fabric-react';
 
 import { Template, PostedTemplate } from 'adaptive-templating-service-typescript-node';
@@ -13,6 +13,7 @@ import { updateTemplate } from '../../../store/currentTemplate/actions';
 
 // Components
 import AdaptiveCard from '../AdaptiveCard';
+import ModalHOC from '../../../utils/ModalHOC';
 
 // Styles
 import {
@@ -92,4 +93,4 @@ class PublishModal extends React.Component<Props> {
   }
 }
 
-export default connect(() => { return {} }, mapDispatchToProps)(PublishModal);
+export default ModalHOC(connect(() => { return {} }, mapDispatchToProps)(PublishModal));

--- a/private-templates-service/client/src/components/Common/PublishModal/PublishModal.tsx
+++ b/private-templates-service/client/src/components/Common/PublishModal/PublishModal.tsx
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 
 // Libraries
 import { TextField } from 'office-ui-fabric-react/lib/TextField';
-import { PrimaryButton } from 'office-ui-fabric-react'
+import { PrimaryButton } from 'office-ui-fabric-react';
 import { SearchBox } from 'office-ui-fabric-react';
 
 import { Template, PostedTemplate } from 'adaptive-templating-service-typescript-node';

--- a/private-templates-service/client/src/utils/ModalHOC.tsx
+++ b/private-templates-service/client/src/utils/ModalHOC.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+const ModalHOC = <P extends object>(Component: React.ComponentType<P>) =>
+  class modalHOC extends React.Component<P> {
+    modal = document.getElementById('modal');
+
+    render() {
+      const { ...props } = this.props;
+      return this.modal ? ReactDOM.createPortal(<Component {...props as P} />, this.modal) : null;
+    }
+  }
+
+export default ModalHOC;


### PR DESCRIPTION
[AB#33910](https://microsoftgarage.visualstudio.com/002806e2-ebaa-4672-9d2e-5fe5d29154ef/_workitems/edit/33910)

## Bug Description
Previously, users can interact with the navbar even when a modal is open. This is because the modal is previously a child of a dashboard component. No matter how high the z-index is set, it will never be positioned higher than the navbar, which only shares a common ancestor node. 

## Solution
The modal must be positioned higher up in the DOM so the navbar and the modal are direct decedents of each other. This was done easily with [React Portals](https://reactjs.org/docs/portals.html). From now on, all modals should use the ModalHOC component. 