### PR TITLE
Allow non REST-endpoint URLS to be handled by the client

### DIFF
--- a/private-templates-service/server/src/app.ts
+++ b/private-templates-service/server/src/app.ts
@@ -35,6 +35,7 @@ mongoDB.connect()
         app.use("/template", client.expressMiddleware());
         app.use("/user", client.userExpressMiddleware());
 
+        // Keep this request at the end so it has lowest priority
         app.get('*', (req, res) => {
           res.sendFile(path.join(__dirname, RELATIVE_PATH_CLIENT + '/index.html'));
         })

--- a/private-templates-service/server/src/app.ts
+++ b/private-templates-service/server/src/app.ts
@@ -8,11 +8,14 @@ import { TemplateServiceClient } from "../../adaptivecards-templating-service/sr
 import { ClientOptions } from "../../adaptivecards-templating-service/src/IClientOptions";
 import { AzureADProvider } from "../../adaptivecards-templating-service/src/authproviders/AzureADProvider";
 import { MongoDBProvider } from "../../adaptivecards-templating-service/src/storageproviders/MongoDBProvider";
+
+const RELATIVE_PATH_CLIENT = '../../../../client/build';
+
 // import mongo, create new mongo, pass options
 const app = express();
 
 // Express configuration
-app.use(express.static(path.join(__dirname, "../../../../client/build")));
+app.use(express.static(path.join(__dirname, RELATIVE_PATH_CLIENT)));
 app.use(passport.initialize());
 app.use(passport.session());
 app.use(bodyParser.json());
@@ -31,6 +34,10 @@ mongoDB.connect()
         const client: TemplateServiceClient = TemplateServiceClient.init(mongoClient);
         app.use("/template", client.expressMiddleware());
         app.use("/user", client.userExpressMiddleware());
+
+        app.get('*', (req, res) => {
+          res.sendFile(path.join(__dirname, RELATIVE_PATH_CLIENT + '/index.html'));
+        })
       } else {
         console.log(res.errorMessage);
       }


### PR DESCRIPTION
[AB#33908](https://microsoftgarage.visualstudio.com/002806e2-ebaa-4672-9d2e-5fe5d29154ef/_workitems/edit/33908)

## Description
Previously, URLs like `/preview` and `/designer` would not load. This is because we were not serving the frontend for all URLs, only the root URL `/`.

This change allows the frontend to be served so long as no other endpoints have other definitions. This means our rest endpoints will have priority over the frontend, which is the expected behavior. 