### PR TITLE
Fix render bug

### DIFF
--- a/private-templates-service/client/src/components/Dashboard/PreviewModal/styled.tsx
+++ b/private-templates-service/client/src/components/Dashboard/PreviewModal/styled.tsx
@@ -36,6 +36,7 @@ export const ACPanel = styled.div`
 
 export const ACWrapper = styled.div`
   padding-bottom: 160px;
+  max-width: 100%;
 `;
 
 export const DescriptorWrapper = styled.div`


### PR DESCRIPTION
[AB#33964](https://microsoftgarage.visualstudio.com/002806e2-ebaa-4672-9d2e-5fe5d29154ef/_workitems/edit/33964)

## Description
For unknown reasons, a small number of templates do not render properly on the template preview page. This one liner fixes that.

### Previously:
![image](https://user-images.githubusercontent.com/19780117/75934820-773bb980-5e32-11ea-885c-d69246115cb8.png)


### Now: 
![image](https://user-images.githubusercontent.com/19780117/75934807-6b4ff780-5e32-11ea-8883-5f27298c7896.png)


