### PR TITLE
Fix client flag bug in backend 

### DIFF
--- a/private-templates-service/adaptivecards-templating-service/src/TemplateServiceClient.ts
+++ b/private-templates-service/adaptivecards-templating-service/src/TemplateServiceClient.ts
@@ -1006,7 +1006,7 @@ export class TemplateServiceClient {
       let isClient: boolean | undefined = req.query.isClient ? req.query.isClient.toLowerCase() === "true" : undefined;
       
       if (!req.is("application/json")) {
-        isClient = req.body.isClient.toLowerCase() === "true";
+        isClient = req.body.isClient && req.body.isClient.toLowerCase() === "true";
       }
 
       let tagList: string[] = req.query.tags? req.query.tags.split(",") : undefined;
@@ -1094,8 +1094,8 @@ export class TemplateServiceClient {
       let isPublished: boolean = req.body.isPublished;
       let isShareable: boolean = req.body.isShareable;
       if (!req.is("application/json")) {
-        isPublished = req.body.isPublished.toLowerCase() === "true";
-        isShareable = req.body.isShareable.toLowerCase() === "true";
+        isPublished = req.body.isPublished && req.body.isPublished.toLowerCase() === "true";
+        isShareable = req.body.isShareable && req.body.isShareable.toLowerCase() === "true";
       }
 
       let tags: string[] | string = req.body.tags;

--- a/private-templates-service/adaptivecards-templating-service/src/TemplateServiceClient.ts
+++ b/private-templates-service/adaptivecards-templating-service/src/TemplateServiceClient.ts
@@ -1004,10 +1004,6 @@ export class TemplateServiceClient {
       let isPublished: boolean | undefined = req.query.isPublished ? req.query.isPublished.toLowerCase() === "true" : undefined;
       let owned: boolean | undefined = req.query.owned ? req.query.owned.toLowerCase() === "true" : undefined;
       let isClient: boolean | undefined = req.query.isClient ? req.query.isClient.toLowerCase() === "true" : undefined;
-      
-      if (!req.is("application/json")) {
-        isClient = req.body.isClient && req.body.isClient.toLowerCase() === "true";
-      }
 
       let tagList: string[] = req.query.tags? req.query.tags.split(",") : undefined;
 


### PR DESCRIPTION
This PR removes an unused isClient check in the backend code that causes the backend to return an error. 