### PR TITLE
Multiple user bug fix

### DIFF
--- a/private-templates-service/adaptivecards-templating-service/src/TemplateServiceClient.ts
+++ b/private-templates-service/adaptivecards-templating-service/src/TemplateServiceClient.ts
@@ -959,8 +959,8 @@ export class TemplateServiceClient {
    * Async function for authenticating users before running endpoint code.
    */
   private _routerAuthentication = async (req: Request, res: Response, next: NextFunction) => {
-    if (req.method === "OPTIONS") {
-      next();
+    if (req.method === "OPTIONS" || req.path.includes('preview')) {
+      return next();
     }
 
     if (!req.headers.authorization) {
@@ -987,17 +987,17 @@ export class TemplateServiceClient {
     var router = express.Router();
 
     // Verify signature of access token before requests.
-    router.all("/*", this._routerAuthentication);
+    router.all("*", this._routerAuthentication);
 
     router.get("/", (req: Request, res: Response, _next: NextFunction) => {
       if (req.query.sortBy && !(req.query.sortBy in SortBy)) {
         const err = new TemplateError(ApiError.InvalidQueryParam, "Sort by value is not valid.");
-        res.status(400).json({ error: err });
+        return res.status(400).json({ error: err });
       }
 
       if (req.query.sortOrder && !(req.query.sortOrder in SortOrder)) {
         const err = new TemplateError(ApiError.InvalidQueryParam, "Sort order value is not valid.");
-        res.status(400).json({ error: err });
+        return res.status(400).json({ error: err });
       }
 
       let isPublished: boolean | undefined = req.query.isPublished ? req.query.isPublished.toLowerCase() === "true" : undefined;

--- a/private-templates-service/adaptivecards-templating-service/src/TemplateServiceClient.ts
+++ b/private-templates-service/adaptivecards-templating-service/src/TemplateServiceClient.ts
@@ -987,7 +987,7 @@ export class TemplateServiceClient {
     var router = express.Router();
 
     // Verify signature of access token before requests.
-    router.all("/", this._routerAuthentication);
+    router.all("/*", this._routerAuthentication);
 
     router.get("/", (req: Request, res: Response, _next: NextFunction) => {
       if (req.query.sortBy && !(req.query.sortBy in SortBy)) {

--- a/private-templates-service/adaptivecards-templating-service/src/TemplateServiceClient.ts
+++ b/private-templates-service/adaptivecards-templating-service/src/TemplateServiceClient.ts
@@ -4,14 +4,13 @@ import { AuthenticationProvider } from ".";
 import { TemplateError, ApiError, ServiceErrorMessage } from "./models/errorModels";
 import { StorageProvider } from ".";
 import { ITemplate, JSONResponse, ITemplateInstance, IUser } from ".";
-import { SortBy, SortOrder, TemplatePreview, TemplateState, TemplateInstancePreview, UserPreview, TagList } from "./models/models";
-import { updateTemplateToLatestInstance, removeMostRecentTemplate, getTemplateVersion, isValidJSONString, setTemplateInstanceParam, incrementVersion, anyVersionsLive, sortTemplateByVersion } from "./util/templateutils";
+import { SortBy, SortOrder, TemplatePreview, TemplateState, TemplateInstancePreview, TagList } from "./models/models";
+import { updateTemplateToLatestInstance, removeMostRecentTemplate, getTemplateVersion, isValidJSONString, setTemplateInstanceParam, incrementVersion, anyVersionsLive, sortTemplateByVersion, parseToken } from "./util/templateutils";
 
 export class TemplateServiceClient {
   private storageProvider: StorageProvider;
   private authProvider: AuthenticationProvider;
-  private ownerID: string | undefined;
-
+  
   /**
    * @public
    * Initialize database if not already running
@@ -44,13 +43,13 @@ export class TemplateServiceClient {
     return this.storageProvider.connect();
   }
 
-  /**
+ /**
    * @private
    * Check if user has already been authenticated.
    */
-  private _checkAuthenticated(): JSONResponse<any> {
-    let owner = this.authProvider.getOwner();
-    if (!owner) {
+  private _checkAuthenticated(token?: string): JSONResponse<any> {
+    let accessToken = token || this.authProvider.token;
+    if (!this.authProvider.isValid(accessToken)) {
       return {
         success: false,
         errorMessage: ServiceErrorMessage.AuthFailureResponse
@@ -60,34 +59,49 @@ export class TemplateServiceClient {
   }
 
   /**
+   * Return user id from database.
+   * @param authID 
+   */
+  private async _getUserID(authId: string): Promise<JSONResponse<string>> {
+    let response = await this._getUser(authId);
+    if (!response.success || (response.result && response.result.length === 0)) {
+      return { success: false, errorMessage: ServiceErrorMessage.UserNotFound };
+    }
+
+    return { success: true, result: response.result![0]._id };
+  }
+
+  /**
    * @public
    * Deletes user info - can only delete own user and all templates created by that user
    */
-  public async removeUser(): Promise<JSONResponse<Number>> {
-    let checkAuthentication = this._checkAuthenticated();
-    if (!checkAuthentication.success) {
-      return checkAuthentication;
+  public async removeUser(token?: string): Promise<JSONResponse<Number>> {
+    let authCheck = this._checkAuthenticated(token);
+    if (!authCheck.success) {
+      return authCheck;
     }
 
-    if (!this.ownerID) return { success: true };
+    let authId = this.authProvider.getAuthIDFromToken(token || this.authProvider.token);
+    let userResponse = await this._getUserID(authId);
+    if (!userResponse.success) {
+      return { success: false, errorMessage: ServiceErrorMessage.UserNotFound };
+    }
+    let userId = userResponse.result;
 
     // Remove all unpublished templates under user
     const template: Partial<ITemplate> = {
-      owner: this.ownerID,
+      owner: userId,
       isLive: false
     };
 
     let deleteTemplateResponse = await this.storageProvider.removeTemplate(template);
 
     const user: IUser = {
-      authId: this.authProvider.getOwner()!,
+      authId: authId,
       authIssuer: this.authProvider.issuer
     };
 
     let removeUserResponse = await this.storageProvider.removeUser(user);
-    if (removeUserResponse.success) {
-      this.ownerID = undefined;
-    }
 
     if (!deleteTemplateResponse.success || !removeUserResponse.success) {
       return {
@@ -100,52 +114,26 @@ export class TemplateServiceClient {
   }
 
   /**
-   * @public
-   * Public update user info function.
-   * @param {string} firstName
-   * @param {string}lastName
-   * @param {string[]} team
-   * @param {string[]} org
-   */
-  public async updateUser(firstName?: string, lastName?: string, team?: string[], org?: string[]): Promise<JSONResponse<Number>> {
-    return this._updateUser(firstName, lastName, team, org);
-  }
-
-  /**
    * @private
-   * Update user info and recently viewed.
-   * @param {string} firstName
-   * @param {string} lastName
-   * @param {string[]} team
-   * @param {string[]} org
+   * Update and recently viewed, edited, tags.
+   * @param {string} authId
    * @param {string[]} recentlyViewed - list of template ids last viewed by the logged in user, should be of length 5 or less
    * @param {string[]} recentlyEdited - list of template ids last edited by the logged in user, should be of length 5 or less
-   * @param {string[]} recentTags - list of tags lsat used by the logged in user, should be of length 10 or less
+   * @param {string[]} recentTags - list of tags last used by the logged in user, should be of length 10 or less
    */
   private async _updateUser(
-    firstName?: string,
-    lastName?: string,
-    team?: string[],
-    org?: string[],
+    authId: string,
     recentlyViewed?: string[],
     recentlyEdited?: string[],
     recentTags?: string[]
   ): Promise<JSONResponse<Number>> {
-    let checkAuthentication = this._checkAuthenticated();
-    if (!checkAuthentication.success) {
-      return checkAuthentication;
-    }
 
     const userQuery: Partial<IUser> = {
-      authId: this.authProvider.getOwner()!,
+      authId: authId,
       authIssuer: this.authProvider.issuer
     };
 
     const user: Partial<IUser> = {
-      firstName: firstName,
-      lastName: lastName,
-      team: team,
-      org: org,
       recentlyViewedTemplates: recentlyViewed,
       recentlyEditedTemplates: recentlyEdited,
       recentTags: recentTags
@@ -157,108 +145,71 @@ export class TemplateServiceClient {
   /**
    * @private
    * Get own user info.
-   * Will return success if user does not exist but query is successful.
+   * Will return success if user exists and is unique.
+   * Creates a new user and returns user if user does not already exist. 
    */
-  private async _getUser(): Promise<JSONResponse<IUser[]>> {
-    let checkAuthentication = this._checkAuthenticated();
-    if (!checkAuthentication.success) {
-      return checkAuthentication;
-    }
-
-    const user: IUser = {
-      authId: this.authProvider.getOwner()!,
+  private async _getUser(authId: string): Promise<JSONResponse<IUser[]>> {
+    const query: Partial<IUser> = {
+      authId: authId,
       authIssuer: this.authProvider.issuer
     };
 
-    return this.storageProvider.getUsers(user);
+    let result = await this.storageProvider.getUsers(query);
+    if (!result.success) {
+      // User does not exist
+      let createUserResponse = await this._postUser(authId);
+      if (!createUserResponse.success) {
+        return { success: false, errorMessage: createUserResponse.errorMessage };
+      }
+      result = await this.storageProvider.getUsers(query);
+    }
+    if (!result.success){
+      return { success: false, errorMessage: ServiceErrorMessage.UserNotFound }
+    }
+    return result;
   }
 
   /**
-   * @private
-   * Get other user's public info: {firstName, lastName, team, org}
-   * Used by the template preview.
+   * @public
+   * Get own user info. 
+   * @param token 
    */
-  private async _searchUserInfo(id: string): Promise<JSONResponse<UserPreview>> {
-    const query: Partial<IUser> = {
-      _id: id
-    };
-
-    let response = await this.storageProvider.getUsers(query);
-    if (!response.success || (response.result && response.result.length === 0)) {
-      return { success: false, errorMessage: ServiceErrorMessage.UserNotFound };
+  public async getUser(token?: string): Promise<JSONResponse<IUser>> { 
+    let authCheck = this._checkAuthenticated(token || this.authProvider.token);
+    if (!authCheck.success) {
+      return authCheck;
     }
 
-    let user = response.result![0];
-    const userInfo: UserPreview = {
-      firstName: user.firstName || "",
-      lastName: user.lastName || "",
-      team: user.team,
-      org: user.org
-    };
-
-    return { success: true, result: userInfo };
+    let userResponse = await this._getUser(this.authProvider.getAuthIDFromToken(token || this.authProvider.token));
+    if (userResponse.success){
+      return { success: true, result: userResponse.result![0]}
+    }
+    return { success: false, errorMessage: userResponse.errorMessage };
   }
 
   /**
    * @private
    * Creates new user object, updates instance ownerID if successful.
-   * @param {string[]} team - user's team within org
-   * @param {string[]} org - user's organization
-   * @param {string} firstName
-   * @param {string} lastName
-   * @param {string[]} recentlyViewed - list of ids of
+   * @param {string[]} recentlyViewed - list of template ids last viewed by the logged in user, should be of length 5 or less
+   * @param {string[]} recentlyEdited - list of template ids last edited by the logged in user, should be of length 5 or less
+   * @param {string[]} recentTags - list of tags last used by the logged in user, should be of length 10 or less
    */
   private async _postUser(
-    team?: string[],
-    org?: string[],
-    firstName?: string,
-    lastName?: string,
+    authId: string,
     recentlyViewed?: string[],
     recentlyEdited?: string[],
     recentTags?: string[]
   ): Promise<JSONResponse<string>> {
-    let checkAuthentication = this._checkAuthenticated();
-    if (!checkAuthentication.success) {
-      return checkAuthentication;
-    }
-
     const user: IUser = {
-      authId: this.authProvider.getOwner()!,
+      authId: authId,
       authIssuer: this.authProvider.issuer,
-      firstName: firstName || "",
-      lastName: lastName || "",
-      team: team || [],
-      org: org || [],
       recentlyViewedTemplates: recentlyViewed || [],
       recentlyEditedTemplates: recentlyEdited || [],
       recentTags: recentTags || []
     };
 
-    let response = await this.storageProvider.insertUser(user);
-    if (response.success && response.result) {
-      this.ownerID = response.result;
-    }
-    return response;
-  }
-
-  /**
-   * @private
-   * Helper function to check if user exists and create a new user if not.
-   */
-  private async _createUser(): Promise<JSONResponse<string>> {
-    // Check if user exists, if not, create new user
-    let userResponse = await this._getUser();
-    if (!userResponse.success || (userResponse.result && userResponse.result.length === 0)) {
-      let newUser = await this._postUser();
-      if (!newUser.success || !newUser.result) {
-        return {
-          success: false,
-          errorMessage: ServiceErrorMessage.InvalidUser
-        };
-      }
-    } else if (userResponse.success && userResponse.result && userResponse.result[0]._id) {
-      this.ownerID = userResponse.result[0]._id;
-    } else {
+    let newUser = await this.storageProvider.insertUser(user);
+    if (!newUser.success) {
       return {
         success: false,
         errorMessage: ServiceErrorMessage.InvalidUser
@@ -322,10 +273,12 @@ export class TemplateServiceClient {
    * @param template
    * @param owned
    */
-  private _getOwnedTemplates(templates: ITemplate[], owned: boolean): ITemplate[] {
+  private async _getOwnedTemplates(authId: string, templates: ITemplate[], owned: boolean): Promise<ITemplate[]> {
+    let user = await this._getUserID(authId);
     let result: ITemplate[] = [];
+    if (!user.success) return result;
     for (let instance of templates) {
-      let isOwner = instance.owner === this.ownerID;
+      let isOwner = instance.owner === user.result;
       if ((isOwner && owned) || (!isOwner && !owned)) {
         result.push(instance);
       }
@@ -360,14 +313,15 @@ export class TemplateServiceClient {
     tag?: string,
     tagList?: string[],
     data?: JSON,
-    dataList?: JSON[]
+    dataList?: JSON[],
+    token?: string
   ): Promise<JSONResponse<Number>> {
     const queryTemplate: Partial<ITemplate> = {
       _id: templateId
     };
 
     // Check if version already exists
-    let response = await this.getTemplates(templateId);
+    let response = await this.getTemplates(token, templateId);
     if (!response.success || !response.result || response.result.length === 0) {
       return { success: false };
     }
@@ -462,11 +416,14 @@ export class TemplateServiceClient {
     } else {
       templateInstances.push(templateInstance);
     }
+    let userResponse = await this._getUserID(this.authProvider.getAuthIDFromToken(token || this.authProvider.token));
+    if (!userResponse.success) return { success: false, errorMessage: userResponse.errorMessage };
+
     const newTemplate: Partial<ITemplate> = {
       name: templateName,
       instances: templateInstances,
       tags: tags,
-      owner: this.ownerID!,
+      owner: userResponse.result,
       updatedAt: new Date(Date.now()),
       isLive: anyVersionsLive(templateInstances)
     };
@@ -497,16 +454,19 @@ export class TemplateServiceClient {
     state?: TemplateState,
     isShareable?: boolean,
     tags?: string[] | string,
-    data?: JSON[] | JSON
+    data?: JSON[] | JSON,
+    token?: string
   ): Promise<JSONResponse<String>> {
-    let checkAuthentication = this._checkAuthenticated();
-    if (!checkAuthentication.success) {
-      return checkAuthentication;
+    let authCheck = this._checkAuthenticated(token);
+    if (!authCheck.success) {
+      return authCheck;
     }
 
-    if (!this.ownerID) {
-      let response = await this._createUser();
-      if (!response.success) return response;
+    let authId = this.authProvider.getAuthIDFromToken(token || this.authProvider.token);
+    let userResponse = await this._getUser(authId);
+
+    if (!userResponse.success) {
+      return { success: false, errorMessage: userResponse.errorMessage };
     }
 
     // Updating existing template
@@ -542,13 +502,14 @@ export class TemplateServiceClient {
         tag,
         tagList,
         dataItem,
-        dataList
+        dataList,
+        token
       );
 
       let newTags = tag ? [tag] : tagList ? tagList : [];
       // Update recent tags and recently edited template
-      await this._updateRecentTags(newTags);
-      await this._updateRecentTemplate(templateId, false);
+      await this._updateRecentTags(authId, newTags);
+      await this._updateRecentTemplate(authId, templateId, false);
 
       if (response.success) {
         return { success: true };
@@ -574,9 +535,14 @@ export class TemplateServiceClient {
 
     let newTags = tags ? (tags instanceof Array ? tags : [tags]) : [];
 
+    let userIdResponse = await this._getUserID(authId);
+    if (!userIdResponse.success) {
+      return userIdResponse;
+    }
+
     const newTemplate: ITemplate = {
       name: templateName,
-      owner: this.ownerID!,
+      owner: userIdResponse.result!,
       instances: [templateInstance],
       tags: newTags,
       deletedVersions: [],
@@ -585,12 +551,12 @@ export class TemplateServiceClient {
     };
 
     // Update recent tags for user
-    await this._updateRecentTags(newTags);
+    await this._updateRecentTags(authId, newTags);
 
     let response = await this.storageProvider.insertTemplate(newTemplate);
     if (response.success && response.result) {
       templateId = response.result;
-      await this._updateRecentTemplate(templateId, false);
+      await this._updateRecentTemplate(authId, templateId, false);
     }
     return response;
   }
@@ -600,11 +566,11 @@ export class TemplateServiceClient {
    * Update user's recent tags list
    * @param tags
    */
-  private async _updateRecentTags(tags: string[]): Promise<JSONResponse<Number>> {
+  private async _updateRecentTags(authId: string, tags: string[]): Promise<JSONResponse<Number>> {
     if (tags.length === 0) return { success: true };
 
     // Update recently viewed for user
-    let user = await this._getUser();
+    let user = await this._getUser(authId);
     if (!user.success || !user.result || user.result.length !== 1) {
       return { success: false };
     }
@@ -620,7 +586,7 @@ export class TemplateServiceClient {
       }
       recentTags!.push(tag);
     }
-    return await this._updateUser(undefined, undefined, undefined, undefined, undefined, undefined, recentTags);
+    return await this._updateUser(authId, undefined, undefined, recentTags);
   }
 
   /**
@@ -628,9 +594,9 @@ export class TemplateServiceClient {
    * @param templateId
    * @param viewed - if true, adds given template id to viewed list for logged in user, otherwise adds to edited list
    */
-  private async _updateRecentTemplate(templateId: string, viewed: boolean): Promise<JSONResponse<Number>> {
+  private async _updateRecentTemplate(authId: string, templateId: string, viewed: boolean): Promise<JSONResponse<Number>> {
     // Update recently viewed for user
-    let user = await this._getUser();
+    let user = await this._getUser(authId);
     if (!user.success || !user.result || user.result.length !== 1) {
       return { success: false };
     }
@@ -645,9 +611,9 @@ export class TemplateServiceClient {
     }
     recentList!.push(templateId);
     if (viewed) {
-      return await this._updateUser(undefined, undefined, undefined, undefined, recentList);
+      return await this._updateUser(authId, recentList);
     }
-    return await this._updateUser(undefined, undefined, undefined, undefined, undefined, recentList);
+    return await this._updateUser(authId, undefined, recentList);
   }
 
   /**
@@ -666,6 +632,7 @@ export class TemplateServiceClient {
    * @returns Promise as valid json
    */
   public async getTemplates(
+    token?: string,
     templateId?: string,
     isPublished?: boolean,
     templateName?: string,
@@ -676,25 +643,23 @@ export class TemplateServiceClient {
     tags?: string[],
     isClient?: boolean
   ): Promise<JSONResponse<ITemplate[]>> {
-    let checkAuthentication = this._checkAuthenticated();
-    if (!checkAuthentication.success) {
-      return checkAuthentication;
+    let authCheck = this._checkAuthenticated(token);
+    if (!authCheck.success) {
+      return authCheck;
+    }
+    let authId = this.authProvider.getAuthIDFromToken(token || this.authProvider.token);
+    let userResponse = await this._getUser(authId);
+
+    if (!userResponse.success || !userResponse.result || userResponse.result.length === 0) {
+      return { success: false, errorMessage: userResponse.errorMessage };
     }
 
-    if (owned && !this.ownerID) {
-      let response = await this._createUser();
-      if (!response.success)
-        return {
-          success: false,
-          errorMessage: ServiceErrorMessage.InvalidUser
-        };
-    }
-
+    let userId = userResponse.result![0]._id;
     const templateQuery: Partial<ITemplate> = {
       _id: templateId,
       name: templateName,
       tags: tags,
-      owner: owned ? this.ownerID : undefined
+      owner: owned ? userId : undefined
     };
 
     let response = await this.storageProvider.getTemplates(templateQuery, sortBy, sortOrder);
@@ -704,7 +669,7 @@ export class TemplateServiceClient {
     let templates: ITemplate[] = response.result;
 
     if (owned === false) {
-      templates = this._getOwnedTemplates(templates, owned);
+      templates = await this._getOwnedTemplates(authId, templates, owned);
     }
 
     if (isPublished || isPublished === false) {
@@ -719,7 +684,9 @@ export class TemplateServiceClient {
     }
 
     if (templateId && templates.length > 0) {
-      await this._updateRecentTemplate(templateId, true);
+      if (templates![0].owner !== userId) return { success: true, result: [] };
+
+      await this._updateRecentTemplate(authId, templateId, true);
 
       if (isClient === undefined || isClient === false) {
         // Update hit counter for template
@@ -732,6 +699,7 @@ export class TemplateServiceClient {
     // Filter for the latest template version (instance)
     let resultTemplates: ITemplate[] = [];
     for (let template of templates) {
+      if (template.isLive === false && template.owner !== userId) continue;
       if (!template.instances) continue;
       if (version) {
         for (let instance of template.instances) {
@@ -757,14 +725,20 @@ export class TemplateServiceClient {
    * @param {string} templateId
    * @param {string} version
    */
-  public async deleteTemplate(templateId: string, version?: string): Promise<JSONResponse<Number>> {
-    let checkAuthentication = this._checkAuthenticated();
-    if (!checkAuthentication.success) {
-      return checkAuthentication;
+  public async deleteTemplate(templateId: string, version?: string, token?: string): Promise<JSONResponse<Number>> {
+    let authCheck = this._checkAuthenticated(token);
+    if (!authCheck.success) {
+      return authCheck;
+    }
+    let authId = this.authProvider.getAuthIDFromToken(token || this.authProvider.token);
+    let userResponse = await this._getUser(authId);
+
+    if (!userResponse.success ) {
+      return { success: false, errorMessage: userResponse.errorMessage };
     }
 
     // Get template instance, check owner and isPublished
-    let response = await this.getTemplates(templateId);
+    let response = await this.getTemplates(token, templateId);
     if (!response.success || !response.result) {
       return { success: false, errorMessage: response.errorMessage };
     }
@@ -773,7 +747,7 @@ export class TemplateServiceClient {
     }
     let template = response.result[0];
 
-    if (template.owner !== this.ownerID || template.isLive) {
+    if (template.owner !==  userResponse.result![0]._id || template.isLive) {
       return { success: false, errorMessage: ServiceErrorMessage.UnauthorizedAction };
     }
 
@@ -838,15 +812,10 @@ export class TemplateServiceClient {
       data: templateVersion.data ? templateVersion.data : []
     };
 
-    let userInfo = await this._searchUserInfo(template.owner);
-    if (!userInfo.success || !userInfo.result) {
-      return { success: false, errorMessage: ServiceErrorMessage.FailedToRetrievePreview };
-    }
-
     let templatePreview: TemplatePreview = {
       _id: templateId,
       name: template.name,
-      owner: userInfo.result!,
+      owner: template.owner,
       instance: templateInstance,
       tags: template.tags || []
     };
@@ -858,14 +827,9 @@ export class TemplateServiceClient {
    * @private
    * @param viewed - If true, returns last 5 viewed templates, otherwise last 5 edited templates
    */
-  private async _getRecentTemplates(viewed: boolean): Promise<JSONResponse<ITemplate[]>> {
-    let checkAuthentication = this._checkAuthenticated();
-    if (!checkAuthentication.success) {
-      return checkAuthentication;
-    }
-
+  private async _getRecentTemplates(viewed: boolean, token?: string): Promise<JSONResponse<ITemplate[]>> {
     let results: ITemplate[] = [];
-    let response = await this._getUser();
+    let response = await this._getUser(this.authProvider.getAuthIDFromToken(token || this.authProvider.token));
     if (!response.success || (response.result && response.result.length === 0)) {
       return { success: false, errorMessage: response.errorMessage };
     }
@@ -877,7 +841,7 @@ export class TemplateServiceClient {
 
     let templateList = viewed ? user.recentlyViewedTemplates : user.recentlyEditedTemplates;
     for (let templateId of templateList!) {
-      let templateResponse = await this.getTemplates(templateId);
+      let templateResponse = await this.getTemplates(token, templateId);
       if (templateResponse.success && templateResponse.result && templateResponse.result.length === 1) {
         results.push(templateResponse.result[0]);
       }
@@ -888,30 +852,39 @@ export class TemplateServiceClient {
    * @public
    * Retrieve a list of recently viewed templates for the logged in user.
    */
-  public async getRecentlyViewedTemplates(): Promise<JSONResponse<ITemplate[]>> {
-    return this._getRecentTemplates(true);
+  public async getRecentlyViewedTemplates(token?: string): Promise<JSONResponse<ITemplate[]>> {
+    let authCheck = this._checkAuthenticated(token);
+    if (!authCheck.success) {
+      return authCheck;
+    }
+    return this._getRecentTemplates(true, token);
   }
 
   /**
    * @public
    * Retrieve a list of recently edited templates for the logged in user.
    */
-  public async getRecentlyEditedTemplates(): Promise<JSONResponse<ITemplate[]>> {
-    return this._getRecentTemplates(false);
+  public async getRecentlyEditedTemplates(token?: string): Promise<JSONResponse<ITemplate[]>> {
+    let authCheck = this._checkAuthenticated(token);
+    if (!authCheck.success) {
+      return authCheck;
+    }
+    return this._getRecentTemplates(false, token);
   }
 
   /**
    * @public
    * Retrieve a list of recently used tags for the logged in user.
    */
-  public async getRecentTags(): Promise<JSONResponse<string[]>> {
-    let checkAuthentication = this._checkAuthenticated();
-    if (!checkAuthentication.success) {
-      return checkAuthentication;
+  public async getRecentTags(token?: string): Promise<JSONResponse<string[]>> {
+    let authCheck = this._checkAuthenticated(token);
+    if (!authCheck.success) {
+      return authCheck;
     }
 
-    let response = await this._getUser();
-    if (!response.success || (response.result && response.result.length === 0)) {
+    let authId = this.authProvider.getAuthIDFromToken(token || this.authProvider.token);
+    let response = await this._getUser(authId);
+    if (!response.success) {
       return { success: false, errorMessage: response.errorMessage };
     }
 
@@ -923,19 +896,25 @@ export class TemplateServiceClient {
    * @public
    * Get a list of tags available for logged in user to query by
    */
-  public async getTags(): Promise<JSONResponse<TagList>> {
-    let checkAuthentication = this._checkAuthenticated();
-    if (!checkAuthentication.success) {
-      return checkAuthentication;
+  public async getTags(token?: string): Promise<JSONResponse<TagList>> {
+    let authCheck = this._checkAuthenticated(token);
+    if (!authCheck.success) {
+      return authCheck;
+    }
+
+    let authId = this.authProvider.getAuthIDFromToken(token || this.authProvider.token);
+    let userResponse = await this._getUser(authId);
+    if (!userResponse.success) {
+      return { success: false, errorMessage: userResponse.errorMessage };
     }
 
     let allTags = new Set();
     let ownedTags = new Set();
-    let response = await this.getTemplates();
+    let response = await this.getTemplates(token);
     if (!response.success || !response.result) return { success: false, errorMessage: response.errorMessage };
     for (let template of response.result) {
       if (!template.tags) continue;
-      if (template.owner === this.ownerID) {
+      if (template.owner === userResponse.result![0]._id) {
         for (let tag of template.tags) {
           ownedTags.add(tag);
         }
@@ -990,6 +969,7 @@ export class TemplateServiceClient {
     router.all("*", this._routerAuthentication);
 
     router.get("/", (req: Request, res: Response, _next: NextFunction) => {
+      let token = parseToken(req.headers.authorization!);
       if (req.query.sortBy && !(req.query.sortBy in SortBy)) {
         const err = new TemplateError(ApiError.InvalidQueryParam, "Sort by value is not valid.");
         return res.status(400).json({ error: err });
@@ -1006,7 +986,7 @@ export class TemplateServiceClient {
 
       let tagList: string[] = req.query.tags ? req.query.tags.split(",") : undefined;
 
-      this.getTemplates(undefined, isPublished, req.query.name, req.query.version,
+      this.getTemplates(token, undefined, isPublished, req.query.name, req.query.version,
         owned, req.query.sortBy, req.query.sortOrder, tagList, isClient).then(response => {
           if (!response.success) {
             return res.status(200).json({ templates: [] });
@@ -1015,20 +995,21 @@ export class TemplateServiceClient {
         });
     });
 
-    router.get("/recent", async (_req: Request, res: Response, _next: NextFunction) => {
-      let response = await this.getRecentlyViewedTemplates();
+    router.get("/recent", async (req: Request, res: Response, _next: NextFunction) => {
+      let token = parseToken(req.headers.authorization!);
+      let response = await this.getRecentlyViewedTemplates(token);
       let recentlyViewedTemplates: ITemplate[] = [];
       if (response.success && response.result) {
         recentlyViewedTemplates = response.result;
       }
 
-      response = await this.getRecentlyEditedTemplates();
+      response = await this.getRecentlyEditedTemplates(token);
       let recentlyEditedTemplates: ITemplate[] = [];
       if (response.success && response.result) {
         recentlyEditedTemplates = response.result;
       }
 
-      let tagResponse = await this.getRecentTags();
+      let tagResponse = await this.getRecentTags(token);
       let recentTags: string[] = [];
       if (tagResponse.success && tagResponse.result) {
         recentTags = tagResponse.result;
@@ -1047,8 +1028,9 @@ export class TemplateServiceClient {
       });
     });
 
-    router.get("/tag", (_req: Request, res: Response, _next: NextFunction) => {
-      this.getTags().then(response => {
+    router.get("/tag", (req: Request, res: Response, _next: NextFunction) => {
+      let token = parseToken(req.headers.authorization!);
+      this.getTags(token).then(response => {
         if (!response.success) {
           return res.status(400).send();
         }
@@ -1058,8 +1040,8 @@ export class TemplateServiceClient {
 
     router.get("/:id?", (req: Request, res: Response, _next: NextFunction) => {
       let isClient: boolean | undefined = req.query.isClient ? req.query.isClient.toLowerCase() === "true" : undefined;
-
-      this.getTemplates(req.params.id, undefined, undefined, req.query.version, undefined, undefined, undefined, undefined, isClient).then(
+      let token = parseToken(req.headers.authorization!);
+      this.getTemplates(token, req.params.id, undefined, undefined, req.query.version, undefined, undefined, undefined, undefined, isClient).then(
         response => {
           if (!response.success || (response.result && response.result.length === 0)) {
             const err = new TemplateError(ApiError.TemplateNotFound, `Template with id ${req.params.id} does not exist.`);
@@ -1081,6 +1063,7 @@ export class TemplateServiceClient {
     });
 
     router.post("/:id*?", async (req: Request, res: Response, _next: NextFunction) => {
+      let token = parseToken(req.headers.authorization!);
       if (req.body.template !== undefined && (!(req.body.template instanceof Object) || !isValidJSONString(JSON.stringify(req.body.template)))) {
         const err = new TemplateError(ApiError.InvalidTemplate, `Template must be valid JSON.`);
         return res.status(400).json({ error: err });
@@ -1106,7 +1089,8 @@ export class TemplateServiceClient {
           req.body.state,
           isShareable,
           tags,
-          data
+          data, 
+          token
         )
         : await this.postTemplates(
           req.body.template,
@@ -1117,7 +1101,8 @@ export class TemplateServiceClient {
           req.body.state,
           isShareable,
           tags,
-          data
+          data, 
+          token
         );
 
       if (!response.success) {
@@ -1129,7 +1114,8 @@ export class TemplateServiceClient {
     });
 
     router.delete("/:id*?", (req: Request, res: Response, _next: NextFunction) => {
-      this.deleteTemplate(req.params.id, req.query.version).then(response => {
+      let token = parseToken(req.headers.authorization!);
+      this.deleteTemplate(req.params.id, req.query.version, token).then(response => {
         if (!response.success) {
           const err = new TemplateError(ApiError.DeleteTemplateVersionFailed, `Failed to delete template ${req.params.id} version.`);
           return res.status(404).json({ error: err });
@@ -1152,8 +1138,9 @@ export class TemplateServiceClient {
     // Verify signature of access token before requests.
     router.all("/", this._routerAuthentication);
 
-    router.get("/", (_req: Request, res: Response, _next: NextFunction) => {
-      this._getUser().then(response => {
+    router.get("/", (req: Request, res: Response, _next: NextFunction) => {
+      let token = parseToken(req.headers.authorization!);
+      this.getUser(token).then(response => {
         if (!response.success) {
           return res.status(200).json({ user: [] });
         }
@@ -1161,17 +1148,9 @@ export class TemplateServiceClient {
       });
     });
 
-    router.post("/", (req: Request, res: Response, _next: NextFunction) => {
-      this.updateUser(req.body.firstName, req.body.lastName, req.body.team, req.body.org).then(response => {
-        if (!response.success) {
-          return res.status(400);
-        }
-        res.status(200).send();
-      });
-    });
-
-    router.delete("/", (_req: Request, res: Response, _next: NextFunction) => {
-      this.removeUser().then(response => {
+    router.delete("/", (req: Request, res: Response, _next: NextFunction) => {
+      let token = parseToken(req.headers.authorization!);
+      this.removeUser(token).then(response => {
         if (!response.success) {
           const err = new TemplateError(ApiError.DeleteUserInfoFailed, "Failed to delete user.");
           return res.status(500).json({ error: err });

--- a/private-templates-service/adaptivecards-templating-service/src/authproviders/IAuthenticationProvider.ts
+++ b/private-templates-service/adaptivecards-templating-service/src/authproviders/IAuthenticationProvider.ts
@@ -6,14 +6,14 @@ import { AuthIssuer } from "../models/models";
 export interface AuthenticationProvider {
   // Issuer and owner fields unique identify every user
   issuer: AuthIssuer;
+  token: string;
 
   /**
-   * To get an id that uniquely identifies the user from
-   * the access token
-   * @returns string or undefined if client is not authenticated
+   * Gets the unique id that identifies the user from the token.
+   * @param accessToken 
    */
-  getOwner: () => string | undefined;
-
+  getAuthIDFromToken(accessToken: string): string;
+  
   /**
    * Validate signature of access token and assigns owner.
    * @throws error - invalid signature

--- a/private-templates-service/adaptivecards-templating-service/src/models/models.ts
+++ b/private-templates-service/adaptivecards-templating-service/src/models/models.ts
@@ -93,23 +93,12 @@ export interface TemplateInstancePreview {
 
 /**
  * @interface
- * User information that is viewable by client.
- */
-export interface UserPreview {
-  firstName: string;
-  lastName: string;
-  team?: string[];
-  org?: string[];
-}
-
-/**
- * @interface
  * Template preview.
  */
 export interface TemplatePreview {
   _id: string;
   name: string;
-  owner: UserPreview;
+  owner: string;
   instance: TemplateInstancePreview;
   tags: string[];
 }

--- a/private-templates-service/adaptivecards-templating-service/src/tests/router.test.ts
+++ b/private-templates-service/adaptivecards-templating-service/src/tests/router.test.ts
@@ -336,10 +336,6 @@ describe("Preview Templates", () => {
     expect(template).toHaveProperty("name");
     expect(template).toHaveProperty("owner");
     let owner = template.owner;
-    expect(owner).toHaveProperty("firstName");
-    expect(owner).toHaveProperty("lastName");
-    expect(owner).toHaveProperty("team");
-    expect(owner).toHaveProperty("org");
     expect(template).toHaveProperty("instance");
     let instance = template.instance;
     expect(instance).toHaveProperty("version");

--- a/private-templates-service/adaptivecards-templating-service/src/tests/router.test.ts
+++ b/private-templates-service/adaptivecards-templating-service/src/tests/router.test.ts
@@ -207,7 +207,8 @@ describe("Basic Post Templates", () => {
   afterAll(async () => {
     await mongoose.connection.close();
     for (let id of idsToDelete) {
-      await request(app).delete(`/template/${id}`);
+      await request(app).delete(`/template/${id}`)
+      .set({ Authorization: "Bearer " + token });
     }
   });
 });
@@ -293,7 +294,8 @@ describe("Basic Get Templates", () => {
 
   afterAll(async () => {
     for (let id of idsToDelete) {
-      await request(app).delete(`/template/${id}`);
+      await request(app).delete(`/template/${id}`)
+      .set({ Authorization: "Bearer " + token });
     }
   });
 });
@@ -367,7 +369,8 @@ describe("Preview Templates", () => {
     id = res.body.id;
     idsToDelete.push(id);
 
-    res = await request(app).get(`/template/${id}`);
+    res = await request(app).get(`/template/${id}`)
+      .set({ Authorization: "Bearer " + token });
     expect(res.status).toEqual(200);
     expect(res.body).toHaveProperty("templates");
     expect(res.body.templates).toHaveLength(1);
@@ -382,7 +385,8 @@ describe("Preview Templates", () => {
 
   afterAll(async () => {
     for (let id of idsToDelete) {
-      await request(app).delete(`/template/${id}`);
+      await request(app).delete(`/template/${id}`)
+      .set({ Authorization: "Bearer " + token });
     }
   });
 });
@@ -413,10 +417,12 @@ describe("Delete Templates", () => {
     expect(res.body).toHaveProperty("id");
     id = res.body.id;
 
-    res = await request(app).delete(`/template/${id}`);
+    res = await request(app).delete(`/template/${id}`)
+    .set({ Authorization: "Bearer " + token });
     expect(res.status).toEqual(204);
 
-    res = await request(app).get(`/template/${id}`);
+    res = await request(app).get(`/template/${id}`)
+    .set({ Authorization: "Bearer " + token });
     expect(res.status).toEqual(404);
   });
 
@@ -441,20 +447,24 @@ describe("Delete Templates", () => {
       });
     expect(res.status).toEqual(201);
 
-    res = await request(app).delete(`/template/${id}?version=1.4`);
+    res = await request(app).delete(`/template/${id}?version=1.4`)
+    .set({ Authorization: "Bearer " + token });
     expect(res.status).toEqual(204);
 
-    res = await request(app).get(`/template/${id}?version=1.4`);
+    res = await request(app).get(`/template/${id}?version=1.4`)
+    .set({ Authorization: "Bearer " + token });
     expect(res.status).toEqual(404);
 
-    res = await request(app).get(`/template/${id}`);
+    res = await request(app).get(`/template/${id}`)
+    .set({ Authorization: "Bearer " + token });
     expect(res.status).toEqual(200);
     expect(res.body.templates[0].instances[0].version).toEqual("1.0");
   });
 
   afterAll(async () => {
     for (let id of idsToDelete) {
-      await request(app).delete(`/template/${id}`);
+      await request(app).delete(`/template/${id}`)
+      .set({ Authorization: "Bearer " + token });
     }
   });
 });
@@ -506,7 +516,8 @@ describe("Filtering Templates", () => {
 
   afterAll(async () => {
     for (let id of idsToDelete) {
-      await request(app).delete(`/template/${id}`);
+      await request(app).delete(`/template/${id}`)
+      .set({ Authorization: "Bearer " + token });
     }
   });
 });
@@ -540,7 +551,8 @@ describe("Get Tags", () => {
     id = res.body.id;
     idsToDelete.push(id);
 
-    res = await request(app).get(`/template/${id}`);
+    res = await request(app).get(`/template/${id}`)
+    .set({ Authorization: "Bearer " + token });
     expect(res.body).toHaveProperty("templates");
     expect(res.body.templates).toHaveLength(1);
     let template = res.body.templates[0];
@@ -563,7 +575,8 @@ describe("Get Tags", () => {
 
   // Authenticated post request
   it("should try to get the list of owners and all tags and succeed", async () => {
-    let res = await request(app).get("/template/tag");
+    let res = await request(app).get("/template/tag")
+    .set({ Authorization: "Bearer " + token });
     expect(res.status).toEqual(200);
     expect(res.body).toHaveProperty("ownedTags");
     expect(res.body).toHaveProperty("allTags");
@@ -576,7 +589,8 @@ describe("Get Tags", () => {
 
   afterAll(async () => {
     for (let id of idsToDelete) {
-      await request(app).delete(`/template/${id}`);
+      await request(app).delete(`/template/${id}`)
+      .set({ Authorization: "Bearer " + token });
     }
   });
 });
@@ -783,7 +797,8 @@ describe("Post Templates, and increment version", () => {
   afterAll(async () => {
     await mongoose.connection.close();
     for (let id of idsToDelete) {
-      await request(app).delete(`/template/${id}`);
+      await request(app).delete(`/template/${id}`)
+      .set({ Authorization: "Bearer " + token });
     }
   });
 });

--- a/private-templates-service/adaptivecards-templating-service/src/util/templateutils.ts
+++ b/private-templates-service/adaptivecards-templating-service/src/util/templateutils.ts
@@ -1,6 +1,4 @@
 import { ITemplate, ITemplateInstance, TemplateState } from "../models/models";
-import { version } from "mongoose";
-
 /**
  * @function
  * Updates passed ITemplate object to only have the latest version instance.
@@ -152,4 +150,13 @@ export function isValidJSONString(input: string) {
     return false;
   }
   return true;
+}
+
+/**
+ * Get token from authorization header.
+ * @param token 
+ */
+export function parseToken(token: string): string {
+  let bearer = token.split(/[ ]+/).pop();
+  return bearer || "";
 }


### PR DESCRIPTION
**Background**
The backend uses the access token passed from the client to identify which user is trying to access their templates/info. The server instantiates one instance of the TemplateServiceClient, which connects to the auth and storage provider, which serves multiple users.

The backend also needs to be installed directly by an user using it as a npm package and so needs to support passing in the access token once instead of every time a function is used. 

**Issue**
Previously user information was stored as a class variable in TemplateServiceClient which sometimes caused the wrong user's templates or info to be returned to the client because of callbacks in the backend.

**Changes**
This PR updates each public function in TemplateServiceClient to take an access token. This ensures that each response knows which user is accessing it, instead of relying on nodeJS' single threaded behaviour. 

_Additional Notes_
This PR also copied changes made by Seva's [PR](https://github.com/microsoft/adaptivecards-templates/pull/140), which removes unnecessary user info (first, last name, org, team) and can be merged in before or after.

**Updates to testing this PR locally**
Adding checks for the audience of the passed access token requires that we now run the backend locally to test PRs and update the client access token in `authproviders/AzureADProvider.ts` in the backend library.

