### PR TITLE
Add automatic logout after 30 minutes of inactivity

### DIFF
--- a/private-templates-service/adaptivecards-templating-service/src/storageproviders/InMemoryDBProvider.ts
+++ b/private-templates-service/adaptivecards-templating-service/src/storageproviders/InMemoryDBProvider.ts
@@ -169,6 +169,9 @@ export class InMemoryDBProvider implements StorageProvider {
     if (!instance.publishedAt) {
       instance.publishedAt = new Date("null");
     }
+    if(!instance.lastEditedUser) {
+      instance.lastEditedUser = "";
+    }
   }
   protected _autoCompleteTemplateModel(template: ITemplate): void {
     if (!template.tags) {

--- a/private-templates-service/adaptivecards-templating-service/src/tests_helper/db_t_definition.ts
+++ b/private-templates-service/adaptivecards-templating-service/src/tests_helper/db_t_definition.ts
@@ -32,6 +32,9 @@ function autoCompleteTemplateInstanceModel(instance: ITemplateInstance): void {
   if (!instance.data) {
     instance.data = [];
   }
+  if(!instance.lastEditedUser) {
+    instance.lastEditedUser = "";
+  }
 }
 function autoCompleteTemplateModel(template: ITemplate): void {
   if (!template.tags) {
@@ -68,9 +71,10 @@ function validateMatchingInstances(a: ITemplateInstance, b: ITemplateInstance) {
   expect(a.json).toEqual(b.json);
   expect(a.version).toBe(b.version);
   expect(a.state).toBe(b.state);
-  expect(a.numHits).toBe(a.numHits);
-  expect(a.data).toBe(a.data);
-  expect(a.isShareable).toBe(a.isShareable);
+  expect(a.numHits).toBe(b.numHits);
+  expect(a.data).toEqual(b.data);
+  expect(a.isShareable).toBe(b.isShareable);
+  expect(a.lastEditedUser).toBe(b.lastEditedUser);
 }
 export function validateMatchingTemplates(a: ITemplate, b: ITemplate): void {
   expect(a.instances!.length).toEqual(b.instances!.length);
@@ -166,7 +170,8 @@ export function testDB(db: StorageProvider) {
   it("Completely filled:create & save template successfully", async () => {
     const validTemplateInstance: ITemplateInstance = {
       json: JSON.parse('{"key":"value"}'),
-      version: "1.0"
+      version: "1.0",
+      lastEditedUser: ""
     };
     const validTemplate: ITemplate = {
       name: "validTemplate",

--- a/private-templates-service/client/package-lock.json
+++ b/private-templates-service/client/package-lock.json
@@ -11833,6 +11833,11 @@
 			"resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.4.tgz",
 			"integrity": "sha512-ueZzLmHltszTshDMwyfELDq8zOA803wQ1ZuzCccXa1m57k1PxSHfflPD5W9YIiTXLs0JTLzoj6o1LuM5N6zzNA=="
 		},
+		"react-idle-timer": {
+			"version": "4.2.12",
+			"resolved": "https://registry.npmjs.org/react-idle-timer/-/react-idle-timer-4.2.12.tgz",
+			"integrity": "sha512-YD/2Oe4PU5uRv/TH6zTxykKMHpRHWHPEWCUohda81o/jzsrlgyUrklfy46fd8WjgYhlNkJKsiX/GXJAQQC1hcQ=="
+		},
 		"react-is": {
 			"version": "16.12.0",
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.12.0.tgz",

--- a/private-templates-service/client/package.json
+++ b/private-templates-service/client/package.json
@@ -26,6 +26,7 @@
     "prettier": "^1.19.1",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
+    "react-idle-timer": "^4.2.12",
     "react-redux": "^7.1.3",
     "react-router-dom": "^5.1.2",
     "react-scripts": "3.2.0",

--- a/private-templates-service/client/src/App.tsx
+++ b/private-templates-service/client/src/App.tsx
@@ -25,6 +25,9 @@ import config from "./Config";
 import "bootstrap/dist/css/bootstrap.css";
 import { OuterAppWrapper, MainAppWrapper, MainApp } from "./styled";
 
+// Constants
+import Constants from "./globalConstants"
+
 
 interface State {
   error: ErrorMessageProps | null;
@@ -116,7 +119,7 @@ class App extends Component<Props, State> {
         <IdleTimer
           element={document}
           onIdle={this.onIdle}
-          timeout={1800000} />
+          timeout={Constants.LOGOUT_TIMEOUT} />
         <Switch>
           <Route exact path="/preview/:uuid/:version">
             <Shared authButtonMethod={this.login}></Shared>

--- a/private-templates-service/client/src/App.tsx
+++ b/private-templates-service/client/src/App.tsx
@@ -3,6 +3,7 @@ import { BrowserRouter as Router, Route, Switch } from "react-router-dom";
 import { UserAgentApplication, ClientAuthError } from "msal";
 import { AuthResponse } from 'msal';
 import { initializeIcons } from '@uifabric/icons';
+import IdleTimer from 'react-idle-timer'
 
 // Redux
 import { connect } from "react-redux";
@@ -70,6 +71,7 @@ interface Props {
 
 class App extends Component<Props, State> {
   userAgentApplication: UserAgentApplication;
+  onIdle: () => any;
 
   constructor(props: Props) {
     super(props);
@@ -95,6 +97,7 @@ class App extends Component<Props, State> {
       // Enhance user object with data from Graph
       this.getUserInfo();
     }
+    this.onIdle = this._onIdle.bind(this);
   }
 
   render() {
@@ -110,6 +113,10 @@ class App extends Component<Props, State> {
 
     return (
       <Router>
+        <IdleTimer
+          element={document}
+          onIdle={this.onIdle}
+          timeout={1800000} />
         <Switch>
           <Route exact path="/preview/:uuid/:version">
             <Shared authButtonMethod={this.login}></Shared>
@@ -144,6 +151,12 @@ class App extends Component<Props, State> {
         <div id="modal" />
       </Router >
     );
+  }
+
+  _onIdle() {
+    if(this.props.isAuthenticated) {
+      this.logout();
+    }
   }
 
   login = async () => {

--- a/private-templates-service/client/src/globalConstants.ts
+++ b/private-templates-service/client/src/globalConstants.ts
@@ -1,0 +1,6 @@
+// Store all this files required in client in this file
+enum Constants {
+  LOGOUT_TIMEOUT = 1800000
+}
+
+export default Constants;


### PR DESCRIPTION
This pr addresses [ACB34148](git push --set-upstream origin users/vsevolod/34148-log-out) about logging the user out after 30 minutes of idle time.
It also fixes storage providers tests and InMemoryStorage providers based on models update in https://github.com/microsoft/adaptivecards-templates/pull/147
To test it locally with idle time less than 30 minutes:
Update `timeout` in `client/src/App.tsx`
![image](https://user-images.githubusercontent.com/21356912/76906232-c20cf680-6860-11ea-9c13-dd3063d0113c.png)
