### PR TITLE
Add app access token

### DIFF
--- a/private-templates-service/adaptivecards-templating-service/src/authproviders/AzureADProvider.ts
+++ b/private-templates-service/adaptivecards-templating-service/src/authproviders/AzureADProvider.ts
@@ -47,7 +47,7 @@ export class AzureADProvider implements AuthenticationProvider {
     // Check expiry date on token
     result = result && new Date() <= new Date(decodedToken.payload.exp * 1000);
     // Check aud of token matches the client ID of env app
-    result = result && "#{CLIENT_ID_TOKEN}" === decodedToken.payload.aud;
+    result = result && "#{CLIENT_ID_TOKEN}#" === decodedToken.payload.aud;
 
     return result;
   }

--- a/private-templates-service/adaptivecards-templating-service/src/authproviders/AzureADProvider.ts
+++ b/private-templates-service/adaptivecards-templating-service/src/authproviders/AzureADProvider.ts
@@ -44,8 +44,10 @@ export class AzureADProvider implements AuthenticationProvider {
       }
     }
 
+    // Check expiry date on token
+    result = result && new Date() <= new Date(decodedToken.payload.exp * 1000);
     // Check aud of token matches the client ID of env app
-    result = "#{CLIENT_ID_TOKEN}#" === decodedToken.payload.aud;
+    result = result && "#{CLIENT_ID_TOKEN}" === decodedToken.payload.aud;
 
     return result;
   }

--- a/private-templates-service/client/src/App.tsx
+++ b/private-templates-service/client/src/App.tsx
@@ -3,11 +3,11 @@ import { BrowserRouter as Router, Route, Switch } from "react-router-dom";
 import { UserAgentApplication, ClientAuthError } from "msal";
 import { AuthResponse } from 'msal';
 import { initializeIcons } from '@uifabric/icons';
-import IdleTimer from 'react-idle-timer'
+import IdleTimer from 'react-idle-timer';
 
 // Redux
 import { connect } from "react-redux";
-import { setAccessToken, getUserDetails, getOrgDetails, getProfilePicture, logout } from "./store/auth/actions";
+import { setAccessToken, setGraphAccessToken, getUserDetails, getOrgDetails, getProfilePicture, logout } from "./store/auth/actions";
 import { UserType } from "./store/auth/types";
 import { RootState } from "./store/rootReducer";
 
@@ -46,6 +46,9 @@ const mapDispatchToProps = (dispatch: any) => {
     setAccessToken: (accessToken: AuthResponse) => {
       dispatch(setAccessToken(accessToken));
     },
+    setGraphAccessToken: (accessToken: AuthResponse) => {
+      dispatch(setGraphAccessToken(accessToken));
+    },
     getUserDetails: () => {
       dispatch(getUserDetails());
     },
@@ -63,6 +66,7 @@ const mapDispatchToProps = (dispatch: any) => {
 
 interface Props {
   setAccessToken: (accessToken: AuthResponse) => void;
+  setGraphAccessToken: (graphAccessToken: AuthResponse) => void;
   getUserDetails: () => void;
   getOrgDetails: () => void;
   getProfilePicture: () => void;
@@ -214,11 +218,17 @@ class App extends Component<Props, State> {
       // make a request to the Azure OAuth endpoint to get a token
       let accessToken = await this.userAgentApplication.acquireTokenSilent(
         {
+          scopes: [`api://${config.appId}/Templates.All`]
+        }
+      );
+      this.props.setAccessToken(accessToken);
+
+      let graphAccessToken = await this.userAgentApplication.acquireTokenSilent(
+        {
           scopes: config.scopes
         }
       );
-
-      this.props.setAccessToken(accessToken);
+      this.props.setAccessToken(graphAccessToken);
 
       this.props.getUserDetails();
       this.props.getOrgDetails();

--- a/private-templates-service/client/src/store/auth/actions.ts
+++ b/private-templates-service/client/src/store/auth/actions.ts
@@ -1,10 +1,8 @@
 import {
   LOGOUT,
-  ACCESS_TOKEN_SET,
   GRAPH_ACCESS_TOKEN_SET,
   UserType,
   AuthAction,
-  AccessTokenAction,
   GraphAccessTokenAction,
   GetUserDetailsAction,
   GetOrgDetailsAction,
@@ -35,13 +33,6 @@ export function setGraphAccessToken(graphAccessToken: AuthResponse): GraphAccess
   return {
     type: GRAPH_ACCESS_TOKEN_SET,
     graphAccessToken
-  }
-}
-
-export function setAccessToken(accessToken: AuthResponse): AccessTokenAction {
-  return {
-    type: ACCESS_TOKEN_SET, 
-    accessToken
   }
 }
 

--- a/private-templates-service/client/src/store/auth/actions.ts
+++ b/private-templates-service/client/src/store/auth/actions.ts
@@ -1,8 +1,10 @@
 import {
   LOGOUT,
+  ACCESS_TOKEN_SET,
   GRAPH_ACCESS_TOKEN_SET,
   UserType,
   AuthAction,
+  AccessTokenAction,
   GraphAccessTokenAction,
   GetUserDetailsAction,
   GetOrgDetailsAction,
@@ -33,6 +35,13 @@ export function setGraphAccessToken(graphAccessToken: AuthResponse): GraphAccess
   return {
     type: GRAPH_ACCESS_TOKEN_SET,
     graphAccessToken
+  }
+}
+
+export function setAccessToken(accessToken: AuthResponse): AccessTokenAction {
+  return {
+    type: ACCESS_TOKEN_SET, 
+    accessToken
   }
 }
 

--- a/private-templates-service/client/src/store/auth/actions.ts
+++ b/private-templates-service/client/src/store/auth/actions.ts
@@ -1,9 +1,11 @@
 import {
   LOGOUT,
   ACCESS_TOKEN_SET,
+  GRAPH_ACCESS_TOKEN_SET,
   UserType,
   AuthAction,
   AccessTokenAction,
+  GraphAccessTokenAction,
   GetUserDetailsAction,
   GetOrgDetailsAction,
   GetProfilePictureAction,
@@ -29,9 +31,16 @@ export function logout(): AuthAction {
   }
 }
 
+export function setGraphAccessToken(graphAccessToken: AuthResponse): GraphAccessTokenAction {
+  return {
+    type: GRAPH_ACCESS_TOKEN_SET,
+    graphAccessToken
+  }
+}
+
 export function setAccessToken(accessToken: AuthResponse): AccessTokenAction {
   return {
-    type: ACCESS_TOKEN_SET,
+    type: ACCESS_TOKEN_SET, 
     accessToken
   }
 }
@@ -98,11 +107,11 @@ export function getUserDetails() {
     dispatch(requestUserDetails());
     const state = getState();
 
-    if (!state.auth.accessToken) {
+    if (!state.auth.graphAccessToken) {
       return dispatch(requestUserDetailsFailure());
     }
 
-    const client = getAuthenticatedClient(state.auth.accessToken);
+    const client = getAuthenticatedClient(state.auth.graphAccessToken);
     return client.api('/me').get()
       .then((userDetails: UserType) => {
         dispatch(requestUserDetailsSuccess(userDetails))
@@ -140,11 +149,11 @@ export function getProfilePicture() {
     dispatch(requestProfilePicture());
     const state = getState();
 
-    if (!state.auth.accessToken) {
+    if (!state.auth.graphAccessToken) {
       return dispatch(requestProfilePictureFailure());
     }
 
-    const client = getAuthenticatedClient(state.auth.accessToken);
+    const client = getAuthenticatedClient(state.auth.graphAccessToken);
     return client.api('/me/photos/240x240/$value').get()
       .then((image: Blob) => {
         const imageURL = URL.createObjectURL(image);

--- a/private-templates-service/client/src/store/auth/reducers.ts
+++ b/private-templates-service/client/src/store/auth/reducers.ts
@@ -3,11 +3,13 @@ import {
   AuthAction,
   UserType,
   AccessTokenAction,
+  GraphAccessTokenAction,
   GetUserDetailsAction,
   GetOrgDetailsAction,
   GetProfilePictureAction,
   LOGOUT,
   ACCESS_TOKEN_SET,
+  GRAPH_ACCESS_TOKEN_SET,
   GET_USER_DETAILS,
   GET_USER_DETAILS_FAILURE,
   GET_USER_DETAILS_SUCCESS,
@@ -24,6 +26,7 @@ const initialState: AuthState = {
   user: undefined,
   isFetching: false,
   accessToken: undefined,
+  graphAccessToken: undefined
 }
 
 const initialUserState: UserType = {
@@ -53,7 +56,7 @@ function user(user = initialUserState, action: AuthAction | AccessTokenAction | 
   }
 }
 
-export function authReducer(state = initialState, action: AuthAction | AccessTokenAction | GetUserDetailsAction | GetOrgDetailsAction | GetProfilePictureAction): AuthState {
+export function authReducer(state = initialState, action: AuthAction | AccessTokenAction | GraphAccessTokenAction | GetUserDetailsAction | GetOrgDetailsAction | GetProfilePictureAction): AuthState {
   switch (action.type) {
     case GET_USER_DETAILS:
     case GET_ORG_DETAILS:
@@ -81,6 +84,12 @@ export function authReducer(state = initialState, action: AuthAction | AccessTok
         ...state,
         isAuthenticated: true,
         accessToken: action.accessToken,
+      }
+    case GRAPH_ACCESS_TOKEN_SET:
+      return {
+        ...state,
+        isAuthenticated: true,
+        graphAccessToken: action.graphAccessToken,
       }
     case LOGOUT:
       return {

--- a/private-templates-service/client/src/store/auth/types.ts
+++ b/private-templates-service/client/src/store/auth/types.ts
@@ -5,6 +5,7 @@ export interface AuthState {
   user?: UserType;
   isFetching: boolean;
   accessToken?: AuthResponse;
+  graphAccessToken?: AuthResponse;
 }
 
 export interface UserType {
@@ -16,6 +17,7 @@ export interface UserType {
 
 // Action Types
 export const ACCESS_TOKEN_SET = 'ACCESS_TOKEN_SET';
+export const GRAPH_ACCESS_TOKEN_SET = 'GRAPH_ACCESS_TOKEN_SET';
 
 export const GET_USER_DETAILS = 'GET_USER_DETAILS';
 export const GET_USER_DETAILS_SUCCESS = 'GET_USER_DETAILS_SUCCESS';
@@ -62,3 +64,9 @@ export interface AccessTokenAction {
   type: typeof ACCESS_TOKEN_SET;
   accessToken: AuthResponse;
 }
+
+export interface GraphAccessTokenAction {
+  type: typeof GRAPH_ACCESS_TOKEN_SET;
+  graphAccessToken: AuthResponse;
+}
+

--- a/private-templates-service/client/src/store/currentTemplate/actions.ts
+++ b/private-templates-service/client/src/store/currentTemplate/actions.ts
@@ -18,9 +18,10 @@ import {
   DELETE_TEMPLATE_INSTANCE_FAILURE
 } from './types';
 
-import { Template, TemplateApi, PostedTemplate } from "adaptive-templating-service-typescript-node";
+import { Template, PostedTemplate } from "adaptive-templating-service-typescript-node";
 
 import { RootState } from '../rootReducer';
+import { initClientSDK } from '../../utils/TemplateUtil';
 
 export function newTemplate(): CurrentTemplateAction {
   return {
@@ -314,11 +315,3 @@ function removeSpecificTemplateVersion(template: Template, version: string) {
   template.instances = instanceList;
 }
 
-function initClientSDK(dispatch: any, getState: () => RootState, ): TemplateApi {
-  const api = new TemplateApi();
-  const state = getState();
-  if (state.auth.accessToken) {
-    api.setApiKey(0, `Bearer ${state.auth.accessToken!.idToken.rawIdToken}`);
-  }
-  return api;
-}

--- a/private-templates-service/client/src/store/recentTemplates/actions.ts
+++ b/private-templates-service/client/src/store/recentTemplates/actions.ts
@@ -1,6 +1,5 @@
 import {
-  TemplateList,
-  TemplateApi
+  TemplateList
 } from "adaptive-templating-service-typescript-node";
 import {
   REQUEST_RECENT_TEMPLATES_GET,
@@ -10,6 +9,7 @@ import {
 } from "./types";
 import { RootState } from "../rootReducer";
 import { IncomingMessage } from "http";
+import { initClientSDK } from "../../utils/TemplateUtil";
 
 export function requestRecentTemplates(): RecentTemplatesAction {
   return {
@@ -39,17 +39,8 @@ export function requestRecentTemplatesFailure(
 
 export function getRecentTemplates() {
   return function (dispatch: any, getState: () => RootState) {
-    const appState = getState();
     dispatch(requestRecentTemplates());
-    let api = new TemplateApi();
-    
-    if (appState.auth.accessToken) {
-      api.setApiKey(
-        0,
-        `Bearer ${appState.auth.accessToken!.idToken.rawIdToken}`
-      );
-    }
-
+    const api = initClientSDK(dispatch, getState);
     return api.getRecent().then(response => {
       if (response.response.statusCode && response.response.statusCode === 200) {
         if (response.body.recentlyEdited && response.body.recentlyViewed) {

--- a/private-templates-service/client/src/store/search/actions.ts
+++ b/private-templates-service/client/src/store/search/actions.ts
@@ -8,8 +8,8 @@ import {
 } from './types';
 
 import { IncomingMessage } from 'http';
-import { TemplateApi } from 'adaptive-templating-service-typescript-node';
 import { RootState } from '../rootReducer';
+import { initClientSDK } from '../../utils/TemplateUtil';
 
 export function querySearchBegin(): SearchAction {
   return {
@@ -36,13 +36,8 @@ export function querySearchFailure(error: IncomingMessage): SearchAction {
 
 export function querySearch(searchByTemplateName: string): (dispatch: any, getState: () => RootState) => void {
   return function (dispatch: any, getState: () => RootState) {
-    const appState = getState();
     dispatch(querySearchBegin())
-    
-    let api = new TemplateApi();
-    if (appState.auth.accessToken){
-      api.setApiKey(0, `Bearer ${appState.auth.accessToken!.idToken.rawIdToken}`);
-    }
+    const api = initClientSDK(dispatch, getState);
     
     return api.allTemplates(undefined, true, searchByTemplateName)
       .then(response => {

--- a/private-templates-service/client/src/store/templates/actions.ts
+++ b/private-templates-service/client/src/store/templates/actions.ts
@@ -1,7 +1,8 @@
 import { REQUEST_TEMPLATES_GET, REQUEST_TEMPLATE_GET_SUCCESS, REQUEST_TEMPLATE_GET_FAIL, AllTemplateAction } from "./types";
-import { TemplateApi, TemplateList } from 'adaptive-templating-service-typescript-node';
+import { TemplateList } from 'adaptive-templating-service-typescript-node';
 import { IncomingMessage } from "http";
 import { RootState } from "../rootReducer";
+import { initClientSDK } from "../../utils/TemplateUtil";
 
 export function requestAllTemplates(): AllTemplateAction {
   return {
@@ -25,12 +26,8 @@ export function failGetAll(error: IncomingMessage): AllTemplateAction {
 
 export function getAllTemplates() {
   return function (dispatch: any, getState: () => RootState) {
-    const appState = getState();
     dispatch(requestAllTemplates())
-    let api = new TemplateApi();
-    if (appState.auth.accessToken) {
-      api.setApiKey(0, `Bearer ${appState.auth.accessToken!.idToken.rawIdToken}`);
-    }
+    const api = initClientSDK(dispatch, getState);
     return api.allTemplates(undefined, true)
       .then(response => {
         if (response.response.statusCode && response.response.statusCode === 200) {

--- a/private-templates-service/client/src/utils/TemplateUtil/TemplateUtil.ts
+++ b/private-templates-service/client/src/utils/TemplateUtil/TemplateUtil.ts
@@ -1,4 +1,5 @@
-import { Template, PostedTemplate } from 'adaptive-templating-service-typescript-node';
+import { Template, PostedTemplate, TemplateApi } from 'adaptive-templating-service-typescript-node';
+import { RootState } from "../../store/rootReducer"
 
 export function getLatestVersion(template?: Template): string {
   if (template && template.instances && template.instances[0] && template.instances[0].version) {
@@ -14,4 +15,13 @@ export function getLatestTemplateInstanceState(template: Template): string {
   }
   // should never reach the next line
   return "";
+}
+
+export function initClientSDK(dispatch: any, getState: () => RootState, ): TemplateApi {
+  const api = new TemplateApi();
+  const state = getState();
+  if (state.auth.accessToken) {
+    api.setApiKey(0, `Bearer ${state.auth.accessToken!.accessToken}`);
+  }
+  return api;
 }

--- a/private-templates-service/client/src/utils/TemplateUtil/index.ts
+++ b/private-templates-service/client/src/utils/TemplateUtil/index.ts
@@ -1,3 +1,3 @@
-import { getLatestVersion, getLatestTemplateInstanceState } from './TemplateUtil';
+import { getLatestVersion, getLatestTemplateInstanceState, initClientSDK } from './TemplateUtil';
 
-export { getLatestVersion, getLatestTemplateInstanceState };
+export { getLatestVersion, getLatestTemplateInstanceState, initClientSDK };


### PR DESCRIPTION
**Ticket**: [TASK-34215](https://microsoftgarage.visualstudio.com/Intern%20GitHub/_sprints/taskboard/Adaptive%20Cards/Intern%20GitHub/Y20-VW/10?workitem=34215)

**Issue**
Client was sending the id token that was only refreshed with the user logs in, this PR requests an access token for the registered web app whose audience is our web app rather than Microsoft Graph. This token is automatically refreshed by the AAD client that the frontend uses. The backend checks the expiry date, checks the audience is the web app id, and validates the token against the public certificate published by AAD. 

This PR contains changes from the previous reverted changes in this [PR](https://github.com/microsoft/adaptivecards-templates/pull/166).

**Azure App Registration Changes**
Each app registration now has a scope "Template.All" permission. The client requests a token for the "Tempate.All" scope to get an access token for the web app. The token that is passed to the backend should have this permission as a scope for the user to use the template service.