### PR TITLE
Don't Show Login Error once Authenticated

### DIFF
--- a/private-templates-service/client/src/App.tsx
+++ b/private-templates-service/client/src/App.tsx
@@ -135,7 +135,7 @@ class App extends Component<Props, State> {
             <MainAppWrapper>
               <NavBar />
               <MainApp>
-                {error}
+                {!this.props.isAuthenticated && error}
                 <Switch>
                   <Route exact path="/">
                     <Dashboard authButtonMethod={this.login} />
@@ -157,7 +157,7 @@ class App extends Component<Props, State> {
   }
 
   _onIdle() {
-    if(this.props.isAuthenticated) {
+    if (this.props.isAuthenticated) {
       this.logout();
     }
   }


### PR DESCRIPTION
[AB#34066](https://microsoftgarage.visualstudio.com/002806e2-ebaa-4672-9d2e-5fe5d29154ef/_workitems/edit/34066)

## Description
Sometimes an error will display on logging in, generated by microsoft active directory. This error no longer applies once the user is logged in, so we will not display it. 