### PR TITLE
Fix 'Error loading image' in Recently Viewed Table

### DIFF
--- a/private-templates-service/client/src/components/Dashboard/RecentlyViewed/OwnerAvatar/OwnerAvatar.tsx
+++ b/private-templates-service/client/src/components/Dashboard/RecentlyViewed/OwnerAvatar/OwnerAvatar.tsx
@@ -8,7 +8,7 @@ import { PersonaSize } from 'office-ui-fabric-react/lib/Persona';
 
 interface Props {
   owner?: OwnerType;
-  index: number;
+  index: string;
 }
 
 const mapStateToProps = (state: RootState) => {
@@ -18,6 +18,7 @@ const mapStateToProps = (state: RootState) => {
 };
 
 class OwnerAvatar extends React.Component<Props> {
+
   render() {
     if (this.props.owner && this.props.owner.imageURLs && this.props.owner.imageURLs[this.props.index]) {
       let facepileProps: IFacepileProps = {

--- a/private-templates-service/client/src/components/Dashboard/RecentlyViewed/OwnerInfo/OwnerInfo.tsx
+++ b/private-templates-service/client/src/components/Dashboard/RecentlyViewed/OwnerInfo/OwnerInfo.tsx
@@ -16,33 +16,33 @@ const mapStateToProps = (state: RootState) => {
 
 const mapDispatchToProps = (dispatch: any) => {
   return {
-    getOwnerName: (oID: string, index: number) => {
-      dispatch(getOwnerName(oID, index));
+    getOwnerName: (oID: string) => {
+      dispatch(getOwnerName(oID));
     },
-    getOwnerProfilePicture: (oID: string, index: number) => {
-      dispatch(getOwnerProfilePicture(oID, index));
+    getOwnerProfilePicture: (oID: string) => {
+      dispatch(getOwnerProfilePicture(oID));
     }
   }
 }
 
 interface Props {
   oID: string;
-  index: number;
-  getOwnerName: (oID: string, index: number) => void;
-  getOwnerProfilePicture: (oID: string, index: number) => void;
+  getOwnerName: (oID: string) => void;
+  getOwnerProfilePicture: (oID: string) => void;
   owner?: OwnerType;
 }
 
 class OwnerInfo extends React.Component<Props> {
   constructor(props: Props) {
+
     super(props);
-    this.props.getOwnerName(this.props.oID, this.props.index);
-    this.props.getOwnerProfilePicture(this.props.oID, this.props.index);
+    this.props.getOwnerName(this.props.oID);
+    this.props.getOwnerProfilePicture(this.props.oID);
   }
   render() {
     return (
       <InfoWrapper>
-        <OwnerAvatar index={this.props.index} /> {(this.props.owner && this.props.owner.displayNames) ? this.props.owner.displayNames[this.props.index] : ""}
+        <OwnerAvatar index={this.props.oID} /> {(this.props.owner && this.props.owner.displayNames) ? this.props.owner.displayNames[this.props.oID] : ""}
       </InfoWrapper>
     );
   }

--- a/private-templates-service/client/src/components/Dashboard/RecentlyViewed/RecentlyViewedTable.tsx
+++ b/private-templates-service/client/src/components/Dashboard/RecentlyViewed/RecentlyViewedTable.tsx
@@ -26,9 +26,7 @@ class RecentlyViewedTable extends React.Component<Props> {
   render() {
     const { templates, propsOnClick } = this.props;
     let rows: JSX.Element[] = [];
-    let index: number = -1;
     rows = templates.map((template: Template) => {
-      index++;
       let onClick = () => {
         if (propsOnClick && template.id) {
           propsOnClick(template.id);
@@ -39,7 +37,7 @@ class RecentlyViewedTable extends React.Component<Props> {
       }
 
       return (
-        <RecentlyViewedBodyRow key={index} onClick={onClick}>
+        <RecentlyViewedBodyRow key={template.instances[0]!.lastEditedUser!} onClick={onClick} >
           <RecentlyViewedItem>{template.name}</RecentlyViewedItem>
           <RecentlyViewedItem>
             {template.updatedAt ? getDateString(template.updatedAt) : "N/A"}
@@ -56,7 +54,7 @@ class RecentlyViewedTable extends React.Component<Props> {
               <Status>{template.isLive ? "Published" : "Draft"}</Status>
             </TemplateStateWrapper>
           </RecentlyViewedItem>
-          <RecentlyViewedItem><OwnerInfo oID={template.instances[0]!.lastEditedUser!} index={index}></OwnerInfo></RecentlyViewedItem>
+          < RecentlyViewedItem > <OwnerInfo oID={template.instances[0]!.lastEditedUser!} ></OwnerInfo></RecentlyViewedItem >
         </RecentlyViewedBodyRow >
       );
     });

--- a/private-templates-service/client/src/store/templateOwner/actions.ts
+++ b/private-templates-service/client/src/store/templateOwner/actions.ts
@@ -20,7 +20,7 @@ function requestOwnerName(): GetOwnerNameAction {
   }
 }
 
-function requestOwnerNameSuccess(ownerName: string, index: number): GetOwnerNameAction {
+function requestOwnerNameSuccess(ownerName: string, index: string): GetOwnerNameAction {
   return {
     type: GET_OWNER_NAME_SUCCESS,
     ownerName,
@@ -40,7 +40,7 @@ function requestOwnerProfilePicture(): GetOwnerProfilePictureAction {
   }
 }
 
-function requestOwnerProfilePictureSuccess(ownerImageURL: string, index: number): GetOwnerProfilePictureAction {
+function requestOwnerProfilePictureSuccess(ownerImageURL: string, index: string): GetOwnerProfilePictureAction {
   return {
     type: GET_OWNER_PROFILE_PICTURE_SUCCESS,
     ownerImageURL,
@@ -60,7 +60,7 @@ export function ClearOwners(): ClearOwnersAction {
   }
 }
 
-export function getOwnerName(oID: string, index: number) {
+export function getOwnerName(oID: string) {
   return function (dispatch: any, getState: () => RootState) {
     dispatch(requestOwnerName());
     const state = getState();
@@ -74,7 +74,7 @@ export function getOwnerName(oID: string, index: number) {
         if (!name.value) {
           dispatch(requestOwnerNameFailure());
         } else {
-          dispatch(requestOwnerNameSuccess(name.value, index));
+          dispatch(requestOwnerNameSuccess(name.value, oID));
         }
       }, (fail: any) => {
         dispatch(requestOwnerNameFailure());
@@ -82,7 +82,7 @@ export function getOwnerName(oID: string, index: number) {
   }
 }
 
-export function getOwnerProfilePicture(oID: string, index: number) {
+export function getOwnerProfilePicture(oID: string) {
   return function (dispatch: any, getState: () => RootState) {
     dispatch(requestOwnerProfilePicture());
     const state = getState();
@@ -95,7 +95,7 @@ export function getOwnerProfilePicture(oID: string, index: number) {
     return client.api('/users/' + oID + '/photo/$value').get()
       .then((image: Blob) => {
         const imageURL = URL.createObjectURL(image);
-        dispatch(requestOwnerProfilePictureSuccess(imageURL, index));
+        dispatch(requestOwnerProfilePictureSuccess(imageURL, oID));
       }, (fail: any) => {
         dispatch(requestOwnerProfilePictureFailure());
       })

--- a/private-templates-service/client/src/store/templateOwner/types.ts
+++ b/private-templates-service/client/src/store/templateOwner/types.ts
@@ -4,8 +4,8 @@ export interface OwnerState {
 }
 
 export interface OwnerType {
-  displayNames?: { [index: number]: string; };
-  imageURLs?: { [index: number]: string; };
+  displayNames?: { [index: string]: string; };
+  imageURLs?: { [index: string]: string; };
 }
 
 export const GET_OWNER_NAME = 'GET_OWNER_NAME';
@@ -20,13 +20,13 @@ export const CLEAR_OWNERS = 'CLEAR_OWNERS';
 
 export interface GetOwnerNameAction {
   type: typeof GET_OWNER_NAME | typeof GET_OWNER_NAME_SUCCESS | typeof GET_OWNER_NAME_FAILURE;
-  index?: number;
+  index?: string;
   ownerName?: string;
 }
 
 export interface GetOwnerProfilePictureAction {
   type: typeof GET_OWNER_PROFILE_PICTURE | typeof GET_OWNER_PROFILE_PICTURE_SUCCESS | typeof GET_OWNER_PROFILE_PICTURE_FAILURE;
-  index?: number;
+  index?: string;
   ownerImageURL?: string;
 }
 


### PR DESCRIPTION
Problem:
Previously, the first template in the Recently Viewed Table showed `Error loading image`:
![image](https://user-images.githubusercontent.com/40618774/77573887-94dacc80-6e8e-11ea-8325-dffe4041d821.png)

This is because we are using a dictionary where the keys were numbers to store the owner names/pics. The first key was always '0', but when we checked if '0' was a valid key, it evaluated to false.

Solution:
Although we could have switched the keys to start from '1', I changed the dictionary such that the key is the user's oID. This prevents duplicate values from being stored in the dictionary.

![image](https://user-images.githubusercontent.com/40618774/77574545-6ad5da00-6e8f-11ea-9aed-30b31b5184db.png)
![image](https://user-images.githubusercontent.com/40618774/77574553-6dd0ca80-6e8f-11ea-92f0-a8b38212234d.png)

