### PR TITLE
Making app keyboard navigable

### DIFF
--- a/private-templates-service/client/src/components/AdaptiveCardPanel/AdaptiveCardPanel.tsx
+++ b/private-templates-service/client/src/components/AdaptiveCardPanel/AdaptiveCardPanel.tsx
@@ -6,7 +6,8 @@ import {
   TemplateFooterWrapper,
   TemplateStateWrapper,
   TemplateNameAndDateWrapper,
-  TemplateUpdatedAt
+  TemplateUpdatedAt,
+  ButtonWrapper
 } from "./styled";
 import {
   StatusIndicator,
@@ -19,6 +20,7 @@ import {
   PostedTemplate,
 } from "adaptive-templating-service-typescript-node";
 import { getDateString } from "../../utils/versionUtils";
+import { Button } from "office-ui-fabric-react";
 
 interface Props {
   onClick?: (templateID: string) => void;
@@ -37,26 +39,28 @@ class AdaptiveCardPanel extends React.Component<Props> {
     let version = getLatestVersion(this.props.template);
     let state = getLatestTemplateInstanceState(template)
     return (
-      <Container onClick={this.onClick}>
-        <ACWrapper>
-          <AdaptiveCard cardtemplate={template} templateVersion={version} hoverEffect />
-        </ACWrapper>
-        <TemplateFooterWrapper>
-          <TemplateNameAndDateWrapper>
-            <TemplateName>{template.name}</TemplateName>
-            <TemplateUpdatedAt>
-              {template.updatedAt ? getDateString(template.updatedAt) : "N/A"}
-            </TemplateUpdatedAt>
-          </TemplateNameAndDateWrapper>
-          <TemplateStateWrapper style={{ justifyContent: "center" }}>
-            <StatusIndicator state={template.instances && template.instances[0] && template.instances[0].state ? template.instances[0].state : PostedTemplate.StateEnum.Draft}
-              style={{ marginRight: "10px" }}
-            />
-            <Status>{state}
-            </Status>
-          </TemplateStateWrapper>
-        </TemplateFooterWrapper>
-      </Container>
+      <ButtonWrapper onClick={this.onClick}>
+        <Container>
+          <ACWrapper>
+            <AdaptiveCard cardtemplate={template} templateVersion={version} hoverEffect />
+          </ACWrapper>
+          <TemplateFooterWrapper>
+            <TemplateNameAndDateWrapper>
+              <TemplateName>{template.name}</TemplateName>
+              <TemplateUpdatedAt>
+                {template.updatedAt ? getDateString(template.updatedAt) : "N/A"}
+              </TemplateUpdatedAt>
+            </TemplateNameAndDateWrapper>
+            <TemplateStateWrapper style={{ justifyContent: "center" }}>
+              <StatusIndicator state={template.instances && template.instances[0] && template.instances[0].state ? template.instances[0].state : PostedTemplate.StateEnum.Draft}
+                style={{ marginRight: "10px" }}
+              />
+              <Status>{state}
+              </Status>
+            </TemplateStateWrapper>
+          </TemplateFooterWrapper>
+        </Container>
+      </ButtonWrapper>
     );
   }
 }

--- a/private-templates-service/client/src/components/AdaptiveCardPanel/AdaptiveCardPanel.tsx
+++ b/private-templates-service/client/src/components/AdaptiveCardPanel/AdaptiveCardPanel.tsx
@@ -20,7 +20,6 @@ import {
   PostedTemplate,
 } from "adaptive-templating-service-typescript-node";
 import { getDateString } from "../../utils/versionUtils";
-import { Button } from "office-ui-fabric-react";
 
 interface Props {
   onClick?: (templateID: string) => void;

--- a/private-templates-service/client/src/components/AdaptiveCardPanel/styled.tsx
+++ b/private-templates-service/client/src/components/AdaptiveCardPanel/styled.tsx
@@ -1,11 +1,20 @@
 import styled from "styled-components";
 import { COLORS } from "../../globalStyles";
+import { Button } from "office-ui-fabric-react";
+
+export const ButtonWrapper = styled.button`
+  border-width: 0px;
+  padding: 0px;
+  margin: 0 24px 24px 0;
+  @media only screen and (max-width: 1399px) {
+    margin-bottom: 20px;
+  }
+`;
 
 export const Container = styled.div`
   flex: 1 1 0px;
   display: flex;
   flex-direction: column;
-  margin: 0 24px 24px 0;
   background: white;
   height: 220px;
   min-width: 300px;
@@ -13,9 +22,6 @@ export const Container = styled.div`
   border: 1px solid ${COLORS.BORDER2};
   border-radius: 5px;
   cursor: pointer;
-  @media only screen and (max-width: 1399px) {
-    margin-bottom: 20px;
-  }
 
   &: hover {
     background: ${COLORS.GREYHOVER};
@@ -48,6 +54,7 @@ export const TemplateNameAndDateWrapper = styled.div`
   display: flex;
   flex-direction: column;
   justify-content: flex-start;
+  align-items: baseline;
 `;
 export const TemplateName = styled.div`
   font-size: 0.95rem;

--- a/private-templates-service/client/src/components/AdaptiveCardPanel/styled.tsx
+++ b/private-templates-service/client/src/components/AdaptiveCardPanel/styled.tsx
@@ -1,6 +1,5 @@
 import styled from "styled-components";
 import { COLORS } from "../../globalStyles";
-import { Button } from "office-ui-fabric-react";
 
 export const ButtonWrapper = styled.button`
   border-width: 0px;

--- a/private-templates-service/client/src/components/Dashboard/RecentlyViewed/RecentlyViewedTable.tsx
+++ b/private-templates-service/client/src/components/Dashboard/RecentlyViewed/RecentlyViewedTable.tsx
@@ -16,6 +16,7 @@ import { getDateString } from "../../../utils/versionUtils";
 import { Status } from "../PreviewModal/TemplateInfo/styled";
 import { TemplateStateWrapper } from "../../AdaptiveCardPanel/styled";
 import OwnerInfo from "./OwnerInfo";
+import KeyCode from "../../../globalKeyCodes";
 
 interface Props {
   templates: Template[];
@@ -32,12 +33,17 @@ class RecentlyViewedTable extends React.Component<Props> {
           propsOnClick(template.id);
         }
       };
+      let onKeyDown = (keyStroke: any) => {
+        if (propsOnClick && template.id && keyStroke.keyCode == KeyCode.ENTER) {
+          propsOnClick(template.id);
+        }
+      }
       if (!template || !template.instances || !template.instances[0] || !template.instances[0].lastEditedUser) {
         return <div>Error loading templates</div>
       }
 
       return (
-        <RecentlyViewedBodyRow key={template.instances[0]!.lastEditedUser!} onClick={onClick} >
+        <RecentlyViewedBodyRow key={template.instances[0]!.lastEditedUser!} onClick={onClick} onKeyDown={onKeyDown} tabIndex={0}>
           <RecentlyViewedItem>{template.name}</RecentlyViewedItem>
           <RecentlyViewedItem>
             {template.updatedAt ? getDateString(template.updatedAt) : "N/A"}

--- a/private-templates-service/client/src/globalKeyCodes.ts
+++ b/private-templates-service/client/src/globalKeyCodes.ts
@@ -1,6 +1,7 @@
 enum KeyCode {
   ESC = 27,
-  END = 35
+  END = 35,
+  ENTER = 13
 }
 
 export default KeyCode


### PR DESCRIPTION
[AB#34214](https://microsoftgarage.visualstudio.com/002806e2-ebaa-4672-9d2e-5fe5d29154ef/_workitems/edit/34214)

Used Accessibility Insights Chrome Extension to identify and meet all keyboard navigation requirements.

Most of the site passed the requirements, few changes were needed:
- Making adaptive card panel accessible via keyboard (done by wrapping it in a styled `<button>`)
- Making the list view for "Recently viewed" keyboard accessible (done using `onKeyDown` and `tabIndex`)