### PR TITLE
Fixing AdaptiveCardPanel UI on Unpublish Modal

### DIFF
--- a/private-templates-service/client/src/components/AdaptiveCardPanel/AdaptiveCardPanel.tsx
+++ b/private-templates-service/client/src/components/AdaptiveCardPanel/AdaptiveCardPanel.tsx
@@ -1,4 +1,8 @@
 import * as React from "react";
+
+import { RootState } from "../../store/rootReducer";
+import { connect } from "react-redux";
+
 import {
   Container,
   TemplateName,
@@ -6,62 +10,70 @@ import {
   TemplateFooterWrapper,
   TemplateStateWrapper,
   TemplateNameAndDateWrapper,
-  TemplateUpdatedAt,
-  ButtonWrapper
+  TemplateUpdatedAt
 } from "./styled";
 import {
   StatusIndicator,
   Status
 } from "../Dashboard/PreviewModal/TemplateInfo/styled";
+
 import AdaptiveCard from "../Common/AdaptiveCard";
-import { getLatestVersion, getLatestTemplateInstanceState } from "../../utils/TemplateUtil";
+
 import {
   Template,
   PostedTemplate,
 } from "adaptive-templating-service-typescript-node";
+
+import { getLatestVersion, getLatestTemplateInstanceState } from "../../utils/TemplateUtil";
 import { getDateString } from "../../utils/versionUtils";
+import KeyCode from "../../globalKeyCodes";
 
 interface Props {
   onClick?: (templateID: string) => void;
   template: Template;
+  pageTitle?: string;
 }
 
+const mapStateToProps = (state: RootState) => {
+  return {
+    pageTitle: state.page.currentPage
+  };
+};
+
 class AdaptiveCardPanel extends React.Component<Props> {
-  onClick = () => {
-    if (this.props.onClick && this.props.template.id) {
+  onKeyDown = (event: any) => {
+    if (this.props.onClick && this.props.template.id && event.keyCode === KeyCode.ENTER) {
       this.props.onClick(this.props.template.id);
     }
-  };
+  }
 
   render() {
     let template = this.props.template;
     let version = getLatestVersion(this.props.template);
     let state = getLatestTemplateInstanceState(template)
     return (
-      <ButtonWrapper onClick={this.onClick}>
-        <Container>
-          <ACWrapper>
-            <AdaptiveCard cardtemplate={template} templateVersion={version} hoverEffect />
-          </ACWrapper>
-          <TemplateFooterWrapper>
-            <TemplateNameAndDateWrapper>
-              <TemplateName>{template.name}</TemplateName>
-              <TemplateUpdatedAt>
-                {template.updatedAt ? getDateString(template.updatedAt) : "N/A"}
-              </TemplateUpdatedAt>
-            </TemplateNameAndDateWrapper>
-            <TemplateStateWrapper style={{ justifyContent: "center" }}>
-              <StatusIndicator state={template.instances && template.instances[0] && template.instances[0].state ? template.instances[0].state : PostedTemplate.StateEnum.Draft}
-                style={{ marginRight: "10px" }}
-              />
-              <Status>{state}
-              </Status>
-            </TemplateStateWrapper>
-          </TemplateFooterWrapper>
-        </Container>
-      </ButtonWrapper>
+      <Container tabIndex={this.props.pageTitle && this.props.pageTitle.toLowerCase() === "dashboard" ? 0 : -1} onKeyDown={this.props.pageTitle && this.props.pageTitle.toLowerCase() === "dashboard" ? this.onKeyDown : () => { }}>
+        <ACWrapper>
+          <AdaptiveCard cardtemplate={template} templateVersion={version} hoverEffect />
+        </ACWrapper>
+        <TemplateFooterWrapper>
+          <TemplateNameAndDateWrapper>
+            <TemplateName>{template.name}</TemplateName>
+            <TemplateUpdatedAt>
+              {template.updatedAt ? getDateString(template.updatedAt) : "N/A"}
+            </TemplateUpdatedAt>
+          </TemplateNameAndDateWrapper>
+          <TemplateStateWrapper style={{ justifyContent: "center" }}>
+            <StatusIndicator state={template.instances && template.instances[0] && template.instances[0].state ? template.instances[0].state : PostedTemplate.StateEnum.Draft}
+              style={{ marginRight: "10px" }}
+            />
+            <Status>{state}
+            </Status>
+          </TemplateStateWrapper>
+        </TemplateFooterWrapper>
+      </Container>
     );
   }
 }
 
-export default AdaptiveCardPanel;
+export default connect(mapStateToProps)(AdaptiveCardPanel);

--- a/private-templates-service/client/src/components/AdaptiveCardPanel/AdaptiveCardPanel.tsx
+++ b/private-templates-service/client/src/components/AdaptiveCardPanel/AdaptiveCardPanel.tsx
@@ -41,8 +41,14 @@ const mapStateToProps = (state: RootState) => {
 };
 
 class AdaptiveCardPanel extends React.Component<Props> {
-  onKeyDown = (event: any) => {
+  onKeyDown = (event: React.KeyboardEvent) => {
     if (this.props.onClick && this.props.template.id && event.keyCode === KeyCode.ENTER) {
+      this.props.onClick(this.props.template.id);
+    }
+  }
+
+  onClick = () => {
+    if (this.props.onClick && this.props.template.id) {
       this.props.onClick(this.props.template.id);
     }
   }
@@ -50,9 +56,14 @@ class AdaptiveCardPanel extends React.Component<Props> {
   render() {
     let template = this.props.template;
     let version = getLatestVersion(this.props.template);
-    let state = getLatestTemplateInstanceState(template)
+    let state = getLatestTemplateInstanceState(template);
+
+    const isComponentNavigable = Boolean(this.props.pageTitle && this.props.pageTitle.toLowerCase() === "dashboard");
+    const isStateDefined = Boolean(template.instances && template.instances[0] && template.instances[0].state);
     return (
-      <Container tabIndex={this.props.pageTitle && this.props.pageTitle.toLowerCase() === "dashboard" ? 0 : -1} onKeyDown={this.props.pageTitle && this.props.pageTitle.toLowerCase() === "dashboard" ? this.onKeyDown : () => { }}>
+      <Container tabIndex={isComponentNavigable ? 0 : -1}
+        onKeyDown={isComponentNavigable ? this.onKeyDown : () => { }}
+        onClick={isComponentNavigable ? this.onClick : () => { }}>
         <ACWrapper>
           <AdaptiveCard cardtemplate={template} templateVersion={version} hoverEffect />
         </ACWrapper>
@@ -64,11 +75,10 @@ class AdaptiveCardPanel extends React.Component<Props> {
             </TemplateUpdatedAt>
           </TemplateNameAndDateWrapper>
           <TemplateStateWrapper style={{ justifyContent: "center" }}>
-            <StatusIndicator state={template.instances && template.instances[0] && template.instances[0].state ? template.instances[0].state : PostedTemplate.StateEnum.Draft}
+            <StatusIndicator state={isStateDefined ? template!.instances![0].state : PostedTemplate.StateEnum.Draft}
               style={{ marginRight: "10px" }}
             />
-            <Status>{state}
-            </Status>
+            <Status>{state}</Status>
           </TemplateStateWrapper>
         </TemplateFooterWrapper>
       </Container>

--- a/private-templates-service/client/src/components/AdaptiveCardPanel/styled.tsx
+++ b/private-templates-service/client/src/components/AdaptiveCardPanel/styled.tsx
@@ -1,15 +1,6 @@
 import styled from "styled-components";
 import { COLORS } from "../../globalStyles";
 
-export const ButtonWrapper = styled.button`
-  border-width: 0px;
-  padding: 0px;
-  margin: 0 24px 24px 0;
-  @media only screen and (max-width: 1399px) {
-    margin-bottom: 20px;
-  }
-`;
-
 export const Container = styled.div`
   flex: 1 1 0px;
   display: flex;
@@ -21,7 +12,10 @@ export const Container = styled.div`
   border: 1px solid ${COLORS.BORDER2};
   border-radius: 5px;
   cursor: pointer;
-
+  margin: 0 24px 24px 0;
+  @media only screen and (max-width: 1399px) {
+    margin-bottom: 20px;
+  }
   &: hover {
     background: ${COLORS.GREYHOVER};
   }

--- a/private-templates-service/client/src/components/Common/UnpublishModal/UnpublishModal.tsx
+++ b/private-templates-service/client/src/components/Common/UnpublishModal/UnpublishModal.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { connect } from 'react-redux';
 
 // Libraries
 import { PrimaryButton } from 'office-ui-fabric-react'
@@ -7,11 +6,13 @@ import { PrimaryButton } from 'office-ui-fabric-react'
 import { Template, PostedTemplate } from 'adaptive-templating-service-typescript-node';
 
 // Redux
+import { connect } from 'react-redux';
 import { updateTemplate } from '../../../store/currentTemplate/actions';
 import { closeModal } from '../../../store/page/actions';
 
 // Components
-import AdaptiveCard from '../AdaptiveCard';
+import AdaptiveCardPanel from '../../AdaptiveCardPanel';
+import ModalHOC from '../../../utils/ModalHOC';
 
 // Strings
 import * as STRINGS from '../../../assets/strings';
@@ -23,12 +24,6 @@ import {
 } from './styled';
 
 import {
-  Container,
-  ACWrapper,
-  TemplateName
-} from '../../AdaptiveCardPanel/styled'
-
-import {
   BackDrop,
   Modal,
   Header,
@@ -37,8 +32,6 @@ import {
   ButtonGroup,
   CancelButton,
 } from '../../Common/PublishModal/styled';
-import ModalHOC from '../../../utils/ModalHOC';
-
 
 interface Props {
   template: Template;
@@ -75,12 +68,7 @@ class UnpublishModal extends React.Component<Props> {
           <Description style={{ marginBottom: 0 }}>{STRINGS.UNPUBLISH_CONFIRMATION}<DescriptionAccent>{template.name} - {this.props.templateVersion}</DescriptionAccent>?</Description>
           <Description>{STRINGS.UNPUBLISH_WARNING}</Description>
           <CenterPanelWrapper>
-            <Container>
-              <ACWrapper>
-                <AdaptiveCard cardtemplate={template} templateVersion={this.props.templateVersion} />
-              </ACWrapper>
-              <TemplateName>{template.name}</TemplateName>
-            </Container>
+            <AdaptiveCardPanel template={template} />
           </CenterPanelWrapper>
           <BottomRow>
             <ButtonGroup>


### PR DESCRIPTION
[AB#34320](https://microsoftgarage.visualstudio.com/002806e2-ebaa-4672-9d2e-5fe5d29154ef/_workitems/edit/34320)

This PR reverts the implementation of AdaptiveCardPanel to a be contained by a div rather than a button to reduce UI complications.

The Unpublish Modal was also updated so that it used the AdaptiveCardPanel component rather than the AdaptiveCard component.