### PR TITLE
Keyboard Navigation on Modal View & Keyboard Navigation for Tags

### DIFF
--- a/private-templates-service/client/src/components/Common/Tags/Tags.tsx
+++ b/private-templates-service/client/src/components/Common/Tags/Tags.tsx
@@ -76,9 +76,7 @@ class Tags extends React.Component<Props, State>  {
       if (this.props.tags.includes(tag)) {
         this.highlightTag(tag, this.props.tags);
       }
-      else if (tag === "") {
-        //this.closeAddTag();
-      }
+      else if (tag === "") { }
       else if (this.props.updateTags) {
         this.props.updateTags([...this.props.tags, tag]);
         this.setState({ newTagName: "" });

--- a/private-templates-service/client/src/components/Common/Tags/Tags.tsx
+++ b/private-templates-service/client/src/components/Common/Tags/Tags.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 
 import { RootState } from '../../../store/rootReducer';
+import { ModalState } from '../../../store/page/types';
 
 import { Template } from 'adaptive-templating-service-typescript-node';
 
@@ -21,6 +22,7 @@ import {
 const mapStateToProps = (state: RootState) => {
   return {
     template: state.currentTemplate.template,
+    modalState: state.page.modalState
   }
 }
 
@@ -32,6 +34,7 @@ interface Props {
   template?: Template;
   updateTags?: (tags: string[]) => void;
   tagRemove?: (tag: string) => void;
+  modalState?: ModalState;
 }
 
 interface State {
@@ -74,7 +77,7 @@ class Tags extends React.Component<Props, State>  {
         this.highlightTag(tag, this.props.tags);
       }
       else if (tag === "") {
-        this.closeAddTag();
+        //this.closeAddTag();
       }
       else if (this.props.updateTags) {
         this.props.updateTags([...this.props.tags, tag]);
@@ -108,6 +111,18 @@ class Tags extends React.Component<Props, State>  {
     }
   }
 
+  onKeyDownAddTag = (keyStroke: any) => {
+    if (keyStroke.keyCode === KeyCode.ENTER) {
+      this.openNewTag();
+    }
+  }
+
+  onKeyDownRemoveTag = (tag: string, keyStroke: any) => {
+    if (this.props.tagRemove && keyStroke.keyCode === KeyCode.ENTER) {
+      this.props.tagRemove(tag);
+    }
+  }
+
   render() {
     const {
       tags,
@@ -118,20 +133,20 @@ class Tags extends React.Component<Props, State>  {
     const {
       isAdding
     } = this.state;
-
+    console.log(this.props.modalState);
     return (
       <React.Fragment>
         {tags && tags.map((tag: string) => (
           <Tag ref={(ref: HTMLDivElement) => this.tagRefs[tag] = ref} onAnimationEnd={this.onAnimationEnd} key={tag}>
             <TagText>{tag}</TagText>
             {allowEdit &&
-              <TagCloseIcon key={tag} iconName="ChromeClose" onClick={this.props.tagRemove && (() => this.props.tagRemove!(tag))} />}
+              <TagCloseIcon key={tag} iconName="ChromeClose" onClick={this.props.tagRemove && (() => this.props.tagRemove!(tag))} tabIndex={this.props.modalState ? -1 : 0} onKeyDown={(event: any) => { this.onKeyDownRemoveTag(tag, event) }} />}
           </Tag>
         ))}
-        {allowAddTag && <AddTagWrapper onSubmit={this.submitNewTag} open={isAdding}>
+        {allowAddTag && <AddTagWrapper onSubmit={this.submitNewTag} open={isAdding} >
           <AddTagInput ref={this.addTagInput} open={isAdding} value={this.state.newTagName} maxLength={30} onChange={this.handleChange} onKeyDown={this.onKeyDown} />
-          <TagAddIcon iconName="Add" onClick={this.openNewTag} open={isAdding} />
-          <TagSubmitButton type="submit" open={isAdding}>
+          <TagAddIcon iconName="Add" onClick={this.openNewTag} open={isAdding} onKeyDown={this.onKeyDownAddTag} tabIndex={this.props.modalState ? -1 : 0} />
+          <TagSubmitButton type="submit" open={isAdding} >
             <TagSubmitIcon iconName="CheckMark" />
           </TagSubmitButton>
         </AddTagWrapper>}

--- a/private-templates-service/client/src/components/Common/Tags/Tags.tsx
+++ b/private-templates-service/client/src/components/Common/Tags/Tags.tsx
@@ -76,8 +76,7 @@ class Tags extends React.Component<Props, State>  {
       if (this.props.tags.includes(tag)) {
         this.highlightTag(tag, this.props.tags);
       }
-      else if (tag === "") { }
-      else if (this.props.updateTags) {
+      else if (this.props.updateTags && tag !== "") {
         this.props.updateTags([...this.props.tags, tag]);
         this.setState({ newTagName: "" });
       }

--- a/private-templates-service/client/src/components/Common/Tags/Tags.tsx
+++ b/private-templates-service/client/src/components/Common/Tags/Tags.tsx
@@ -131,7 +131,6 @@ class Tags extends React.Component<Props, State>  {
     const {
       isAdding
     } = this.state;
-    console.log(this.props.modalState);
     return (
       <React.Fragment>
         {tags && tags.map((tag: string) => (

--- a/private-templates-service/client/src/components/Common/Tags/styled.tsx
+++ b/private-templates-service/client/src/components/Common/Tags/styled.tsx
@@ -115,10 +115,6 @@ export const TagSubmitButton = styled.button<{ open: boolean }>`
   &: active {
     outline: 0px;
   }
-
-  &: focus {
-    outline: 0px;
-  }
 `;
 
 export const TagSubmitIcon = styled(Icon)`

--- a/private-templates-service/client/src/components/Dashboard/PreviewModal/PreviewModal.tsx
+++ b/private-templates-service/client/src/components/Dashboard/PreviewModal/PreviewModal.tsx
@@ -25,6 +25,7 @@ import requireAuthentication from '../../../utils/requireAuthentication';
 import { ModalWrapper, ACOuterPanel, StyledDropdown, ACPanel, ACWrapper, DescriptorWrapper, CenteredSpinner } from './styled';
 
 import { Template } from 'adaptive-templating-service-typescript-node';
+import { ModalState } from '../../../store/page/types';
 
 const DropdownOptions = [
   { key: 'sample', text: 'Default', value: Default },
@@ -42,6 +43,7 @@ const mapStateToProps = (state: RootState) => {
   return {
     template: state.currentTemplate.template,
     isFetching: state.currentTemplate.isFetching,
+    modalState: state.page.modalState
   }
 }
 
@@ -65,6 +67,7 @@ interface Props extends RouteComponentProps<MatchParams> {
   isFetching?: boolean;
   setPage: (currentPageTitle: string, currentPage: string) => void;
   getTemplate: (templateID: string) => void;
+  modalState?: ModalState
 }
 
 interface State {
@@ -127,7 +130,7 @@ class PreviewModal extends React.Component<Props, State> {
         {template && !isFetching ?
           <React.Fragment>
             <ACOuterPanel>
-              <StyledDropdown selectedKey={selectedItem.key} onChange={this.hostConfigChange} options={DropdownOptions} />
+              <StyledDropdown selectedKey={selectedItem.key} onChange={this.hostConfigChange} options={DropdownOptions} tabIndex={this.props.modalState ? -1 : 0} />
               <ACPanel>
                 <ACWrapper>
                   <AdaptiveCard cardtemplate={template} templateVersion={this.state.templateVersion} hostConfig={selectedItem.value} />

--- a/private-templates-service/client/src/components/Dashboard/PreviewModal/TemplateInfo/TemplateInfo.tsx
+++ b/private-templates-service/client/src/components/Dashboard/PreviewModal/TemplateInfo/TemplateInfo.tsx
@@ -198,6 +198,7 @@ class TemplateInfo extends React.Component<Props, State> {
                   theme={THEME.LIGHT}
                   styles={DropdownStyles}
                   ariaLabel="Version List Dropdown"
+                  tabIndex={this.props.modalState ? -1 : 0}
                 />
               </Title>
               <StatusIndicator state={templateState} />
@@ -210,7 +211,8 @@ class TemplateInfo extends React.Component<Props, State> {
           <ActionsWrapper>
             {buttons.map((val) => (
               <ActionButton key={val.text} iconProps={val.icon} allowDisabledFocus
-                onClick={() => { onActionButtonClick(this.props, this.state, val) }}>
+                onClick={() => { onActionButtonClick(this.props, this.state, val) }}
+                tabIndex={this.props.modalState ? -1 : 0}>
                 {val.text === 'Publish' && templateState === PostedTemplate.StateEnum.Live ? val.altText : val.text}
               </ActionButton>
             ))}

--- a/private-templates-service/client/src/components/Dashboard/PreviewModal/TemplateInfo/VersionCard/VersionCard.tsx
+++ b/private-templates-service/client/src/components/Dashboard/PreviewModal/TemplateInfo/VersionCard/VersionCard.tsx
@@ -61,7 +61,9 @@ class VersionCard extends React.Component<Props> {
         <CardHeader>
           <VersionCardHeader>
             <CardTitle>Recent Releases</CardTitle>
-            <CardManageButton onClick={() => { this.props.openModal(ModalState.Version) }}>{MANAGE}</CardManageButton>
+            <CardManageButton onClick={() => { this.props.openModal(ModalState.Version) }} tabIndex={this.props.modalState ? -1 : 0}>
+              {MANAGE}
+            </CardManageButton>
           </VersionCardHeader>
         </CardHeader>
         <CardBody>

--- a/private-templates-service/client/src/components/NavBar/NavBar.tsx
+++ b/private-templates-service/client/src/components/NavBar/NavBar.tsx
@@ -31,7 +31,8 @@ const mapStateToProps = (state: RootState) => {
     template: state.currentTemplate.template,
     templateID: state.currentTemplate.templateID,
     isFetching: state.currentTemplate.isFetching,
-    templateName: state.currentTemplate.templateName
+    templateName: state.currentTemplate.templateName,
+    modalState: state.page.modalState
   }
 }
 
@@ -44,6 +45,7 @@ interface NavBarProps {
   isFetching: boolean;
   version?: string;
   templateID?: string;
+  modalState?: ModalState;
 }
 
 
@@ -103,7 +105,7 @@ const NavBar = (props: NavBarProps) => {
             <Styledh1>{(props.templateID === "" && STRINGS.UNTITLEDCARD) || props.templateName}</Styledh1>
             {props.templateID !== "" && <EditButton onClick={editName} iconProps={{ iconName: 'Edit' }} />}
           </MobileBanner>
-          <ActionButton onClick={() => { history.push("/") }}> 
+          <ActionButton onClick={() => { history.push("/") }}>
             <StyledButton>
               <StyledButtonContent>
                 Finish
@@ -128,9 +130,9 @@ const NavBar = (props: NavBarProps) => {
           <BaselineBanner>
             <StyledLogo aria-label={STRINGS.LOGO_DESCRIPTION} src={Logo} />
             <Styledh1>{(props.template && props.template.name) || props.currentPageTitle}</Styledh1>
-            {!props.isFetching && <EditButton ariaLabel="Edit Template Name" onClick={editName} iconProps={{ iconName: 'Edit' }} />}
+            {!props.isFetching && <EditButton ariaLabel="Edit Template Name" onClick={editName} iconProps={{ iconName: 'Edit' }} tabIndex={props.modalState ? -1 : 0} />}
           </BaselineBanner>
-          <BackButton iconProps={{ iconName: 'Back' }} onClick={onBackButton}><ButtonTextWrapper>Back</ButtonTextWrapper></BackButton>
+          <BackButton iconProps={{ iconName: 'Back' }} onClick={onBackButton} tabIndex={props.modalState ? -1 : 0} ><ButtonTextWrapper>Back</ButtonTextWrapper></BackButton>
         </Banner>
       );
     default:

--- a/private-templates-service/client/src/components/SideBar/SideBar.tsx
+++ b/private-templates-service/client/src/components/SideBar/SideBar.tsx
@@ -28,6 +28,7 @@ import {
 } from "./styled";
 import { INavLinkGroup, INavStyles } from "office-ui-fabric-react";
 import { ClearOwners } from "../../store/templateOwner/actions";
+import { ModalState } from "../../store/page/types";
 
 
 interface Props {
@@ -36,13 +37,15 @@ interface Props {
   user?: UserType;
   templateID: string | undefined;
   newTemplate: () => void;
+  modalState?: ModalState;
 }
 
 const mapStateToProps = (state: RootState) => {
   return {
     isAuthenticated: state.auth.isAuthenticated,
     user: state.auth.user,
-    templateID: state.currentTemplate.templateID
+    templateID: state.currentTemplate.templateID,
+    modalState: state.page.modalState
   };
 };
 
@@ -181,7 +184,7 @@ const SideBar = (props: Props) => {
         {props.isAuthenticated && <NavMenu styles={navMenuLinksProps} groups={navMenuLinks} onLinkClick={onNavClick} />}
       </MainItems>
 
-      <SignOut onClick={props.authButtonMethod}>Sign {props.isAuthenticated ? "Out" : "In"}</SignOut>
+      <SignOut onClick={props.authButtonMethod} tabIndex={props.modalState ? -1 : 0}>Sign {props.isAuthenticated ? "Out" : "In"}</SignOut>
     </OuterSideBarWrapper>
   );
 };


### PR DESCRIPTION
[AB#34321](https://microsoftgarage.visualstudio.com/002806e2-ebaa-4672-9d2e-5fe5d29154ef/_workitems/edit/34321)
[AB#34356](https://microsoftgarage.visualstudio.com/002806e2-ebaa-4672-9d2e-5fe5d29154ef/_workitems/edit/34356)

This PR ensures that when a modal is open, buttons in the background are not keyboard accessible.

Also addressed making tagging feature keyboard accessible.