### PR TITLE
Fix Dashboard Bugs

### DIFF
--- a/private-templates-service/client/src/assets/strings.ts
+++ b/private-templates-service/client/src/assets/strings.ts
@@ -67,4 +67,4 @@ export const TAGS = "Tags";
 
 //OwnerAvatar.tsx
 export const ERROR_LOADING_IMAGE = "Error loading image";
-export const ARIA_LABEL = "Template owner profile picture"
+export const ALT_TEXT = "Template owner profile picture"

--- a/private-templates-service/client/src/components/AdaptiveCardPanel/AdaptiveCardPanel.tsx
+++ b/private-templates-service/client/src/components/AdaptiveCardPanel/AdaptiveCardPanel.tsx
@@ -7,7 +7,8 @@ import {
   TemplateStateWrapper,
   TemplateNameAndDateWrapper,
   TemplateUpdatedAt,
-  ButtonWrapper
+  ButtonWrapper,
+  Align
 } from "./styled";
 import {
   StatusIndicator,
@@ -50,13 +51,15 @@ class AdaptiveCardPanel extends React.Component<Props> {
                 {template.updatedAt ? getDateString(template.updatedAt) : "N/A"}
               </TemplateUpdatedAt>
             </TemplateNameAndDateWrapper>
-            <TemplateStateWrapper style={{ justifyContent: "center" }}>
-              <StatusIndicator state={template.instances && template.instances[0] && template.instances[0].state ? template.instances[0].state : PostedTemplate.StateEnum.Draft}
-                style={{ marginRight: "10px" }}
-              />
-              <Status>{state}
-              </Status>
-            </TemplateStateWrapper>
+            <Align>
+              <TemplateStateWrapper style={{ justifyContent: "center" }}>
+                <StatusIndicator state={template.instances && template.instances[0] && template.instances[0].state ? template.instances[0].state : PostedTemplate.StateEnum.Draft}
+                  style={{ marginRight: "10px" }}
+                />
+                <Status>{state}
+                </Status>
+              </TemplateStateWrapper>
+            </Align>
           </TemplateFooterWrapper>
         </Container>
       </ButtonWrapper>

--- a/private-templates-service/client/src/components/AdaptiveCardPanel/styled.tsx
+++ b/private-templates-service/client/src/components/AdaptiveCardPanel/styled.tsx
@@ -73,3 +73,9 @@ export const TemplateUpdatedAt = styled.div`
 export const Bottom = styled.div`
   padding: 20px;
 `;
+
+export const Align = styled.div`
+  display: flex;
+  justify-content: space-between;
+  margin-right: 5px;
+`;

--- a/private-templates-service/client/src/components/Dashboard/PreviewModal/TemplateInfo/styled.tsx
+++ b/private-templates-service/client/src/components/Dashboard/PreviewModal/TemplateInfo/styled.tsx
@@ -70,6 +70,7 @@ export const StatusIndicator = styled.div<{ state?: PostedTemplate.StateEnum }>`
 export const Status = styled.div`
   font-size: 14px;
   font-weight: 400;
+  padding-right: 7px;
 `
 export const TimeStamp = styled.div`
   font-size: 14px;

--- a/private-templates-service/client/src/components/Dashboard/RecentlyViewed/OwnerAvatar/OwnerAvatar.tsx
+++ b/private-templates-service/client/src/components/Dashboard/RecentlyViewed/OwnerAvatar/OwnerAvatar.tsx
@@ -3,40 +3,38 @@ import { connect } from "react-redux";
 import { RootState } from "../../../../store/rootReducer";
 import { OwnerType } from "../../../../store/templateOwner/types";
 
-import { Facepile, IFacepileProps } from 'office-ui-fabric-react/lib/Facepile';
-import { PersonaSize } from 'office-ui-fabric-react/lib/Persona';
-import { ERROR_LOADING_IMAGE, ARIA_LABEL } from "../../../../assets/strings";
+import { ERROR_LOADING_IMAGE, ALT_TEXT } from "../../../../assets/strings";
+import { ProfilePic, Container, InitialsPic, Initials } from "./styled";
 
 interface Props {
   owner?: OwnerType;
-  index: string;
+  oID: string;
 }
 
 const mapStateToProps = (state: RootState) => {
   return {
-    owner: state.templateOwner.owners
+    owner: state.templateOwner.owners,
   };
 };
 
 class OwnerAvatar extends React.Component<Props> {
 
   render() {
-    if (this.props.owner && this.props.owner.imageURLs && this.props.owner.imageURLs[this.props.index]) {
-      let facepileProps: IFacepileProps = {
-        personaSize: PersonaSize.size24,
-        personas: new Array({ imageUrl: this.props.owner.imageURLs[this.props.index] }),
-        ariaLabel: ARIA_LABEL,
-
-      };
-      return (<Facepile {...facepileProps} />)
+    if (this.props.owner && this.props.owner.imageURLs && this.props.owner.imageURLs[this.props.oID]) {
+      return (
+        <Container>
+          <ProfilePic src={this.props.owner.imageURLs[this.props.oID]} alt={ALT_TEXT}></ProfilePic>
+        </Container>)
     }
-    else if (this.props.owner && this.props.owner.displayNames && this.props.owner.displayNames[this.props.index] && this.props.owner.displayNames[this.props.index][0]) {
-      let facepileProps: IFacepileProps = {
-        personaSize: PersonaSize.size24,
-        personas: new Array({ imageInitials: this.props.owner.displayNames[this.props.index][0] }),
-        ariaLabel: ARIA_LABEL
-      };
-      return (<Facepile {...facepileProps} />)
+    else if (this.props.owner && this.props.owner.displayNames && this.props.owner.displayNames[this.props.oID]) {
+      return (
+        <Container>
+          <InitialsPic>
+            <Initials>
+              {this.props.owner.displayNames[this.props.oID][0]}
+            </Initials>
+          </InitialsPic>
+        </Container>)
     }
     return (<div>{ERROR_LOADING_IMAGE}</div>)
   }

--- a/private-templates-service/client/src/components/Dashboard/RecentlyViewed/OwnerAvatar/styled.tsx
+++ b/private-templates-service/client/src/components/Dashboard/RecentlyViewed/OwnerAvatar/styled.tsx
@@ -9,6 +9,7 @@ export const ProfilePic = styled.img`
 
 export const Container = styled.div`
   margin-right: 15px;
+  margin-bottom: 3px;
   `
 
 export const InitialsPic = styled.div`
@@ -21,8 +22,8 @@ export const InitialsPic = styled.div`
   `
 
 export const Initials = styled.div` 
-    text-align: center;
-    font-size: 15px;
-    padding-top: 2.5px;
-    color: ${COLORS.WHITE};
-  `
+  text-align: center;
+  font-size: 15px;
+  padding-top: 2.5px;
+  color: ${COLORS.WHITE};
+`

--- a/private-templates-service/client/src/components/Dashboard/RecentlyViewed/OwnerAvatar/styled.tsx
+++ b/private-templates-service/client/src/components/Dashboard/RecentlyViewed/OwnerAvatar/styled.tsx
@@ -1,0 +1,28 @@
+import styled from 'styled-components';
+import { COLORS } from '../../../../globalStyles';
+
+export const ProfilePic = styled.img`
+  border-radius: 50%;
+  height: 30px;
+  width: 30px;
+`
+
+export const Container = styled.div`
+  margin-right: 15px;
+  `
+
+export const InitialsPic = styled.div`
+  border-radius: 50%;
+  height: 30px;
+  width: 30px;
+  background-color: ${COLORS.BLUE2};
+  justify-content: center;
+  align-items: center;
+  `
+
+export const Initials = styled.div` 
+    text-align: center;
+    font-size: 15px;
+    padding-top: 2.5px;
+    color: ${COLORS.WHITE};
+  `

--- a/private-templates-service/client/src/components/Dashboard/RecentlyViewed/OwnerInfo/OwnerInfo.tsx
+++ b/private-templates-service/client/src/components/Dashboard/RecentlyViewed/OwnerInfo/OwnerInfo.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import { connect } from "react-redux";
 import { RootState } from "../../../../store/rootReducer";
 
-import { getOwnerName, getOwnerProfilePicture } from "../../../../store/templateOwner/actions";
 import { OwnerType } from "../../../../store/templateOwner/types";
 
 import { InfoWrapper } from "./styled";
@@ -14,38 +13,19 @@ const mapStateToProps = (state: RootState) => {
   };
 };
 
-const mapDispatchToProps = (dispatch: any) => {
-  return {
-    getOwnerName: (oID: string) => {
-      dispatch(getOwnerName(oID));
-    },
-    getOwnerProfilePicture: (oID: string) => {
-      dispatch(getOwnerProfilePicture(oID));
-    }
-  }
-}
-
 interface Props {
   oID: string;
-  getOwnerName: (oID: string) => void;
-  getOwnerProfilePicture: (oID: string) => void;
   owner?: OwnerType;
 }
 
 class OwnerInfo extends React.Component<Props> {
-  constructor(props: Props) {
-
-    super(props);
-    this.props.getOwnerName(this.props.oID);
-    this.props.getOwnerProfilePicture(this.props.oID);
-  }
   render() {
     return (
       <InfoWrapper>
-        <OwnerAvatar index={this.props.oID} /> {(this.props.owner && this.props.owner.displayNames) ? this.props.owner.displayNames[this.props.oID] : ""}
+        <OwnerAvatar oID={this.props.oID} /> {(this.props.owner && this.props.owner.displayNames) ? this.props.owner.displayNames[this.props.oID] : ""}
       </InfoWrapper>
     );
   }
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(OwnerInfo);
+export default connect(mapStateToProps)(OwnerInfo);

--- a/private-templates-service/client/src/components/Dashboard/RecentlyViewed/RecentlyViewedTable.tsx
+++ b/private-templates-service/client/src/components/Dashboard/RecentlyViewed/RecentlyViewedTable.tsx
@@ -9,7 +9,8 @@ import {
   RecentlyViewedBodyRow,
   RecentlyViewedItem,
   RecentlyViewedBody,
-  RecentlyViewedStatusIndicator
+  RecentlyViewedStatusIndicator,
+  StatusWrapper
 } from "./styled";
 
 import { getDateString } from "../../../utils/versionUtils";
@@ -57,7 +58,9 @@ class RecentlyViewedTable extends React.Component<Props> {
                     : PostedTemplate.StateEnum.Draft
                 }
               />
-              <Status>{template.isLive ? "Published" : "Draft"}</Status>
+              <StatusWrapper>
+                <Status>{template.isLive ? "Published" : "Draft"}</Status>
+              </StatusWrapper>
             </TemplateStateWrapper>
           </RecentlyViewedItem>
           < RecentlyViewedItem > <OwnerInfo oID={template.instances[0]!.lastEditedUser!} ></OwnerInfo></RecentlyViewedItem >

--- a/private-templates-service/client/src/components/Dashboard/RecentlyViewed/styled.tsx
+++ b/private-templates-service/client/src/components/Dashboard/RecentlyViewed/styled.tsx
@@ -13,6 +13,7 @@ export const RecentlyViewedBodyRow = styled.div`
   flex: 1;
   padding-top: 20px;
   padding-left: 50px;
+  padding-bottom: 2px;
   justify-content: flex-start;
 `;
 

--- a/private-templates-service/client/src/components/Dashboard/RecentlyViewed/styled.tsx
+++ b/private-templates-service/client/src/components/Dashboard/RecentlyViewed/styled.tsx
@@ -11,7 +11,6 @@ export const RecentlyViewedBodyRow = styled.div`
   display: flex;
   flex-direction: row;
   flex: 1;
-  padding-top: 20px;
   padding-left: 50px;
   padding-bottom: 2px;
   justify-content: flex-start;
@@ -36,6 +35,7 @@ export const RecentlyViewedContainer = styled(Card)`
   border-radius: 5px;
   justify-content: flex-start;
   margin-top: 10px;
+  padding-bottom: 0px;
 `;
 
 export const RecentlyViewedBody = styled.div`
@@ -47,9 +47,14 @@ export const RecentlyViewedBody = styled.div`
 export const RecentlyViewedItem = styled.div`
   font-family: Segoe UI Regular;
   flex: 1;
+  padding-top: 6px;
 `;
 
 export const RecentlyViewedStatusIndicator = styled(StatusIndicator)`
   margin-right: 10px;
   margin-left: 0px;
 `;
+
+export const StatusWrapper = styled.div`
+  padding-top: 3px;
+`

--- a/private-templates-service/client/src/components/SideBar/SideBar.tsx
+++ b/private-templates-service/client/src/components/SideBar/SideBar.tsx
@@ -27,8 +27,6 @@ import {
   LogoTextSubHeader
 } from "./styled";
 import { INavLinkGroup, INavStyles } from "office-ui-fabric-react";
-import { ClearOwners } from "../../store/templateOwner/actions";
-
 
 interface Props {
   authButtonMethod: () => void;
@@ -154,9 +152,6 @@ const SideBar = (props: Props) => {
     event.preventDefault();
     if (element.url === "/designer") {
       props.newTemplate();
-    }
-    else if (element.url === "/") {
-      ClearOwners();
     }
     history.push(element.url);
   };

--- a/private-templates-service/client/src/store/templateOwner/actions.ts
+++ b/private-templates-service/client/src/store/templateOwner/actions.ts
@@ -1,14 +1,12 @@
 import {
   GetOwnerNameAction,
   GetOwnerProfilePictureAction,
-  ClearOwnersAction,
   GET_OWNER_NAME,
   GET_OWNER_NAME_SUCCESS,
   GET_OWNER_NAME_FAILURE,
   GET_OWNER_PROFILE_PICTURE,
   GET_OWNER_PROFILE_PICTURE_SUCCESS,
   GET_OWNER_PROFILE_PICTURE_FAILURE,
-  CLEAR_OWNERS,
 } from './types';
 
 import { getAuthenticatedClient } from '../../Services/GraphService';
@@ -51,12 +49,6 @@ function requestOwnerProfilePictureSuccess(ownerImageURL: string, index: string)
 function requestOwnerProfilePictureFailure(): GetOwnerProfilePictureAction {
   return {
     type: GET_OWNER_PROFILE_PICTURE_FAILURE
-  }
-}
-
-export function ClearOwners(): ClearOwnersAction {
-  return {
-    type: CLEAR_OWNERS,
   }
 }
 

--- a/private-templates-service/client/src/store/templateOwner/reducers.ts
+++ b/private-templates-service/client/src/store/templateOwner/reducers.ts
@@ -7,15 +7,14 @@ import {
   GET_OWNER_PROFILE_PICTURE,
   GET_OWNER_PROFILE_PICTURE_SUCCESS,
   GET_OWNER_PROFILE_PICTURE_FAILURE,
-  CLEAR_OWNERS,
   GetOwnerNameAction,
   GetOwnerProfilePictureAction,
-  ClearOwnersAction,
 } from './types';
 
 const initialState: OwnerState = {
   owners: undefined,
-  isFetching: false,
+  isFetchingName: false,
+  isFetchingPicture: false,
 }
 
 const initialOwnerState: OwnerType = {
@@ -46,31 +45,58 @@ function updateOwners(owner = initialOwnerState, action: GetOwnerNameAction | Ge
   }
 }
 
-export function templateOwnerReducer(state = initialState, action: GetOwnerNameAction | GetOwnerProfilePictureAction | ClearOwnersAction): OwnerState {
+function clearOwners(owner = initialOwnerState, action: GetOwnerNameAction | GetOwnerProfilePictureAction): OwnerType | undefined {
   switch (action.type) {
-    // empty case statement will "fall through" to logic in the next non-empty case
     case GET_OWNER_NAME:
+      return {
+        ...owner,
+        displayNames: {}
+      }
+    case GET_OWNER_PROFILE_PICTURE:
+      return {
+        ...owner,
+        imageURLs: {},
+      }
+    default:
+      return owner;
+  }
+}
+
+export function templateOwnerReducer(state = initialState, action: GetOwnerNameAction | GetOwnerProfilePictureAction): OwnerState {
+  switch (action.type) {
+    case GET_OWNER_NAME:
+      return {
+        ...state,
+        owners: clearOwners(state.owners, action),
+        isFetchingName: true,
+      };
     case GET_OWNER_PROFILE_PICTURE:
       return {
         ...state,
-        isFetching: true,
+        owners: clearOwners(state.owners, action),
+        isFetchingPicture: true,
       };
     case GET_OWNER_NAME_FAILURE:
+      return {
+        ...state,
+        isFetchingName: false,
+      }
     case GET_OWNER_PROFILE_PICTURE_FAILURE:
       return {
         ...state,
-        isFetching: false,
+        isFetchingPicture: false,
       }
     case GET_OWNER_NAME_SUCCESS:
+      return {
+        ...state,
+        owners: updateOwners(state.owners, action),
+        isFetchingName: false,
+      }
     case GET_OWNER_PROFILE_PICTURE_SUCCESS:
       return {
         ...state,
         owners: updateOwners(state.owners, action),
-      }
-    case CLEAR_OWNERS:
-      return {
-        ...state,
-        owners: undefined,
+        isFetchingPicture: false,
       }
     default:
       return state;

--- a/private-templates-service/client/src/store/templateOwner/types.ts
+++ b/private-templates-service/client/src/store/templateOwner/types.ts
@@ -1,6 +1,7 @@
 export interface OwnerState {
   owners?: OwnerType;
-  isFetching: boolean;
+  isFetchingName: boolean;
+  isFetchingPicture: boolean;
 }
 
 export interface OwnerType {
@@ -28,8 +29,4 @@ export interface GetOwnerProfilePictureAction {
   type: typeof GET_OWNER_PROFILE_PICTURE | typeof GET_OWNER_PROFILE_PICTURE_SUCCESS | typeof GET_OWNER_PROFILE_PICTURE_FAILURE;
   index?: string;
   ownerImageURL?: string;
-}
-
-export interface ClearOwnersAction {
-  type: typeof CLEAR_OWNERS;
 }


### PR DESCRIPTION
This PR addresses these issues: 

[AB#34256](https://microsoftgarage.visualstudio.com/Intern%20GitHub/_workitems/edit/34256) **"deprecated" text is located too right:**

![image](https://user-images.githubusercontent.com/40618774/77928864-d1774100-725d-11ea-87ab-a046d4b51fba.png)

[AB#34345](https://microsoftgarage.visualstudio.com/Intern%20GitHub/_workitems/edit/34345): **Recently viewed elements on click:**

![image](https://user-images.githubusercontent.com/40618774/77928844-c7edd900-725d-11ea-983c-5945d83dcdbc.png)

[AB#34331](https://microsoftgarage.visualstudio.com/Intern%20GitHub/_workitems/edit/34331) **Profile pictures and names should display on first load:**
![image](https://user-images.githubusercontent.com/40618774/77928918-e3f17a80-725d-11ea-9d3f-0982514566e1.png)

[AB#34326](https://microsoftgarage.visualstudio.com/Intern%20GitHub/_workitems/edit/34326) **Profile picture and name for recently viewed column doesn't load properly:**

**Snapshot of new dashboard:**
![image](https://user-images.githubusercontent.com/40618774/77929402-7a25a080-725e-11ea-9807-625fee12e851.png)

**Videos:**
- Dashboard on refresh: https://microsoft-my.sharepoint.com/:v:/p/t-damott/Ee3jZ4oOPPJHi1By4xKa8ewBp0Y2Soecub9JnRbcO-fiRg?e=F1IWCV
- Dashboard on login: https://microsoft-my.sharepoint.com/:v:/p/t-damott/ERptkc2rT9lBm79U9z2i9p4B88tVXZeIiett3xOskG41mQ?e=95ETvH

_Note:_
- Using the UI fabric component 'Facepile' was causing the pictures to re-render. Removing the Facepile component, fixed the issue of the owner name and picture in Recently Viewed not loading correctly. 
- I ran a fast pass of Accessibility Insights for Web and this PR introduces no new issues.