### PR TITLE
Add skip link to main content

### DIFF
--- a/private-templates-service/client/src/assets/strings.ts
+++ b/private-templates-service/client/src/assets/strings.ts
@@ -68,3 +68,6 @@ export const TAGS = "Tags";
 //OwnerAvatar.tsx
 export const ERROR_LOADING_IMAGE = "Error loading image";
 export const ALT_TEXT = "Template owner profile picture"
+
+// SkipLink.tsx
+export const SKIP_TO_MAIN_CONTENT_MESSAGE = "Skip to main content"

--- a/private-templates-service/client/src/components/Common/SkipLink/SkipLink.tsx
+++ b/private-templates-service/client/src/components/Common/SkipLink/SkipLink.tsx
@@ -10,7 +10,7 @@ interface SkipLinkProps {
 
 const mapStateToProps = (state: RootState) => {
     return {
-        contentID: state.skipLinkReducer.contentID
+        contentID: state.skipLink.contentID
     }
 }
 

--- a/private-templates-service/client/src/components/Common/SkipLink/SkipLink.tsx
+++ b/private-templates-service/client/src/components/Common/SkipLink/SkipLink.tsx
@@ -1,0 +1,25 @@
+import React, { Component } from 'react'
+import { RootState } from '../../../store/rootReducer';
+import { connect } from 'react-redux';
+import { SkipLinkContainer } from './styled';
+import { SKIP_TO_MAIN_CONTENT_MESSAGE } from "../../../assets/strings"
+
+interface SkipLinkProps {
+    contentID?: string;
+}
+
+const mapStateToProps = (state: RootState) => {
+    return {
+        contentID: state.skipLinkReducer.contentID
+    }
+}
+
+class SkipLink extends Component<SkipLinkProps> {
+    render() {
+        return (
+            <SkipLinkContainer href={`#${this.props.contentID}`}>{SKIP_TO_MAIN_CONTENT_MESSAGE}</SkipLinkContainer>
+        )
+    }
+}
+
+export default connect(mapStateToProps)(SkipLink);

--- a/private-templates-service/client/src/components/Common/SkipLink/index.ts
+++ b/private-templates-service/client/src/components/Common/SkipLink/index.ts
@@ -1,0 +1,3 @@
+import SkipLink from "./SkipLink"
+
+export default SkipLink;

--- a/private-templates-service/client/src/components/Common/SkipLink/styled.tsx
+++ b/private-templates-service/client/src/components/Common/SkipLink/styled.tsx
@@ -7,16 +7,14 @@ position: absolute;
 left: -999px;
 top: -999px;
 &: focus {  
-    padding:0 25px 0 25px;
+    font-size: 0.8rem;
+    padding:5px 25px 5px 25px;
     left:0;
     top:75px;
     margin-left: 40px;
-    color: black;
+    color: white;
     outline: none;
-    background: white;
+    background: ${COLORS.BLUE3};
     text-decoration: none;
-};
-&: hover {
-    color: ${COLORS.BLUE};
 };
 `;

--- a/private-templates-service/client/src/components/Common/SkipLink/styled.tsx
+++ b/private-templates-service/client/src/components/Common/SkipLink/styled.tsx
@@ -1,0 +1,22 @@
+import styled from "styled-components";
+import { COLORS } from "../../../globalStyles";
+
+export const SkipLinkContainer = styled.a`
+display: block;
+position: absolute;
+left: -999px;
+top: -999px;
+&: focus {  
+    padding:0 25px 0 25px;
+    left:0;
+    top:75px;
+    margin-left: 40px;
+    color: black;
+    outline: none;
+    background: white;
+    text-decoration: none;
+};
+&: hover {
+    color: ${COLORS.BLUE};
+};
+`;

--- a/private-templates-service/client/src/components/Dashboard/Dashboard.tsx
+++ b/private-templates-service/client/src/components/Dashboard/Dashboard.tsx
@@ -12,6 +12,7 @@ import { getTemplate } from "../../store/currentTemplate/actions";
 import { setSearchBarVisible } from "../../store/search/actions";
 import { getOwnerProfilePicture, getOwnerName } from "../../store/templateOwner/actions";
 import { OwnerState } from "../../store/templateOwner/types";
+import { setSkipLinkContentID } from "../../store/skiplink/actions";
 
 import { Template } from "adaptive-templating-service-typescript-node";
 import { SpinnerSize } from 'office-ui-fabric-react/lib/Spinner';
@@ -71,6 +72,9 @@ const mapDispatchToProps = (dispatch: any) => {
     },
     getOwnerProfilePicture: (oID: string) => {
       dispatch(getOwnerProfilePicture(oID));
+    },
+    setSkipLinkContentID: (id: string) => {
+      dispatch(setSkipLinkContentID(id));
     }
   };
 };
@@ -87,6 +91,7 @@ interface Props extends RouteComponentProps {
   getTemplate: (templateID: string) => void;
   getOwnerName: (oID: string) => void;
   getOwnerProfilePicture: (oID: string) => void;
+  setSkipLinkContentID: (id: string) => void;
   isSearch: boolean;
 }
 class Dashboard extends React.Component<Props> {
@@ -95,6 +100,7 @@ class Dashboard extends React.Component<Props> {
     props.setPage("Dashboard", "Dashboard");
     props.setSearchBarVisible(true);
     props.getRecentTemplates();
+    props.setSkipLinkContentID(DASHBOARD_MAIN_CONTENT_ID);
   }
   componentDidUpdate(prevProps: Props) {
     if (this.props.isSearch !== prevProps.isSearch) {
@@ -151,7 +157,7 @@ class Dashboard extends React.Component<Props> {
     return (
       <OuterDashboardContainer>
         <OuterWindow>
-          <DashboardContainer>
+          <DashboardContainer id={DASHBOARD_MAIN_CONTENT_ID}>
             <React.Fragment>
               <Title>Recently Edited</Title>
               {recentTemplates.isFetching || this.props.templateOwner.isFetchingName || this.props.templateOwner.isFetchingPicture ?
@@ -193,6 +199,7 @@ class Dashboard extends React.Component<Props> {
     );
   }
 }
+export const DASHBOARD_MAIN_CONTENT_ID: string = "dashboard-content";
 
 export default connect(
   mapStateToProps,

--- a/private-templates-service/client/src/components/Dashboard/index.ts
+++ b/private-templates-service/client/src/components/Dashboard/index.ts
@@ -1,3 +1,5 @@
 import Dashboard from './Dashboard';
+import { DASHBOARD_MAIN_CONTENT_ID } from './Dashboard'
 
+export { DASHBOARD_MAIN_CONTENT_ID };
 export default Dashboard;

--- a/private-templates-service/client/src/components/NavBar/NavBar.test.tsx
+++ b/private-templates-service/client/src/components/NavBar/NavBar.test.tsx
@@ -17,7 +17,7 @@ it('Renders without crashing', () => {
   const store = createStore(rootReducer, {});
   ReactDOM.render(
     <Provider store={store}>
-        <NavBar />
+      <NavBar />
     </Provider>, div);
   ReactDOM.unmountComponentAtNode(div);
 });

--- a/private-templates-service/client/src/components/NavBar/NavBar.test.tsx
+++ b/private-templates-service/client/src/components/NavBar/NavBar.test.tsx
@@ -8,7 +8,8 @@ import NavBar from './NavBar';
 jest.mock('react-router-dom', () => ({
   useHistory: () => ({
     push: jest.fn()
-  })
+  }),
+  withRouter: (a: any) => a
 }));
 
 it('Renders without crashing', () => {
@@ -16,7 +17,7 @@ it('Renders without crashing', () => {
   const store = createStore(rootReducer, {});
   ReactDOM.render(
     <Provider store={store}>
-      <NavBar />
+        <NavBar />
     </Provider>, div);
   ReactDOM.unmountComponentAtNode(div);
 });

--- a/private-templates-service/client/src/components/SideBar/SideBar.tsx
+++ b/private-templates-service/client/src/components/SideBar/SideBar.tsx
@@ -28,6 +28,7 @@ import {
   LogoTextSubHeader
 } from "./styled";
 import { INavLinkGroup, INavStyles } from "office-ui-fabric-react";
+import SkipLink from "../Common/SkipLink";
 
 
 interface Props {
@@ -179,6 +180,7 @@ const SideBar = (props: Props) => {
           </Name>
         </UserWrapper>
         {props.isAuthenticated && <NavMenu styles={navMenuLinksProps} groups={navMenuLinks} onLinkClick={onNavClick} />}
+        {props.isAuthenticated && <SkipLink/>}
       </MainItems>
 
       <SignOut onClick={props.authButtonMethod} tabIndex={props.modalState ? -1 : 0}>Sign {props.isAuthenticated ? "Out" : "In"}</SignOut>

--- a/private-templates-service/client/src/globalStyles.tsx
+++ b/private-templates-service/client/src/globalStyles.tsx
@@ -14,9 +14,10 @@ export const COLORS = {
   GREEN: "#00D610",
   YELLOW: "#FFBD53",
   BLUE: "#016FC4",
+  BLUE2: "#02599C",
+  BLUE3: "#5390FF",
   BORDER: "#E6E6E6",
   BORDER2: "#C3C3C3",
-  BLUE2: "#02599C"
 };
 
 export const BREAK = {

--- a/private-templates-service/client/src/store/rootReducer.ts
+++ b/private-templates-service/client/src/store/rootReducer.ts
@@ -6,6 +6,7 @@ import { filterReducer } from "./filter/reducer";
 import { allTemplateReducer } from "./templates/reducer";
 import { recentTemplatesReducer } from "./recentTemplates/reducer";
 import { templateOwnerReducer } from "./templateOwner/reducers";
+import { skipLinkReducer } from "./skiplink/reducer"
 
 import { combineReducers } from "redux";
 import { sortReducer } from "./sort/reducer";
@@ -20,6 +21,7 @@ export const rootReducer = combineReducers({
   allTemplates: allTemplateReducer,
   recentTemplates: recentTemplatesReducer,
   templateOwner: templateOwnerReducer,
+  skipLinkReducer: skipLinkReducer
 });
 
 export type RootState = ReturnType<typeof rootReducer>;

--- a/private-templates-service/client/src/store/rootReducer.ts
+++ b/private-templates-service/client/src/store/rootReducer.ts
@@ -21,7 +21,7 @@ export const rootReducer = combineReducers({
   allTemplates: allTemplateReducer,
   recentTemplates: recentTemplatesReducer,
   templateOwner: templateOwnerReducer,
-  skipLinkReducer: skipLinkReducer
+  skipLink: skipLinkReducer
 });
 
 export type RootState = ReturnType<typeof rootReducer>;

--- a/private-templates-service/client/src/store/skiplink/actions.ts
+++ b/private-templates-service/client/src/store/skiplink/actions.ts
@@ -1,0 +1,8 @@
+import { SET_SKIP_LINK_CONTENT_ID, SkipLinkAction, SkipLinkState } from "./types";
+
+export function setSkipLinkContentID(id: string): SkipLinkAction {
+  return {
+    type: SET_SKIP_LINK_CONTENT_ID,
+    contentID: id
+  };
+}

--- a/private-templates-service/client/src/store/skiplink/actions.ts
+++ b/private-templates-service/client/src/store/skiplink/actions.ts
@@ -1,4 +1,4 @@
-import { SET_SKIP_LINK_CONTENT_ID, SkipLinkAction, SkipLinkState } from "./types";
+import { SET_SKIP_LINK_CONTENT_ID, SkipLinkAction } from "./types";
 
 export function setSkipLinkContentID(id: string): SkipLinkAction {
   return {

--- a/private-templates-service/client/src/store/skiplink/reducer.ts
+++ b/private-templates-service/client/src/store/skiplink/reducer.ts
@@ -1,0 +1,17 @@
+import { SkipLinkState, SET_SKIP_LINK_CONTENT_ID, SkipLinkAction } from "./types";
+import { DASHBOARD_MAIN_CONTENT_ID } from "../../components/Dashboard/Dashboard";
+
+const initialState: SkipLinkState = {
+  contentID: DASHBOARD_MAIN_CONTENT_ID
+};
+export function skipLinkReducer(state = initialState, action: SkipLinkAction): SkipLinkState {
+  switch (action.type) {
+    case SET_SKIP_LINK_CONTENT_ID:
+      return {
+        ...state,
+        contentID: action.contentID
+      };
+    default:
+      return state;
+  }
+}

--- a/private-templates-service/client/src/store/skiplink/reducer.ts
+++ b/private-templates-service/client/src/store/skiplink/reducer.ts
@@ -1,5 +1,5 @@
 import { SkipLinkState, SET_SKIP_LINK_CONTENT_ID, SkipLinkAction } from "./types";
-import { DASHBOARD_MAIN_CONTENT_ID } from "../../components/Dashboard/Dashboard";
+import { DASHBOARD_MAIN_CONTENT_ID } from "../../components/Dashboard";
 
 const initialState: SkipLinkState = {
   contentID: DASHBOARD_MAIN_CONTENT_ID

--- a/private-templates-service/client/src/store/skiplink/types.ts
+++ b/private-templates-service/client/src/store/skiplink/types.ts
@@ -1,0 +1,10 @@
+export const SET_SKIP_LINK_CONTENT_ID = "SET_SKIP_LINK_CONTENT_ID";
+
+export interface SkipLinkState {
+  contentID: string;
+}
+
+export interface SkipLinkAction {
+  type: typeof SET_SKIP_LINK_CONTENT_ID;
+  contentID: string;
+}


### PR DESCRIPTION
This pr addresses [BUG34224](https://microsoftgarage.visualstudio.com/Intern%20GitHub/_workitems/edit/34224) to create a skip to main content link to address accessibility.
The link won't be visible unless it receives a focus and it will get the focus if the user clicks **tab** while focusing on the **Dashboard** link on the SideBar. The link will change the user focus to RecentlyEdited.
![image](https://user-images.githubusercontent.com/21356912/77975128-0c08ca00-72ae-11ea-87ec-d3458b73831f.png)
