### PR TITLE
Removed shadows from Template View Page and Dashboard

### DIFF
--- a/private-templates-service/client/src/components/Dashboard/PreviewModal/TemplateInfo/styled.tsx
+++ b/private-templates-service/client/src/components/Dashboard/PreviewModal/TemplateInfo/styled.tsx
@@ -104,7 +104,8 @@ export const Card = styled.div`
   flex: 0.47 0 0;
   display: flex;
   flex-direction: column;
-  box-shadow: 0px 3px 6px #00000029;
+  border: 1px solid ${COLORS.BORDER2};
+  border-radius: 5px;
   padding: 8px 0px 16px;
   margin-bottom: 24px;
 `;

--- a/private-templates-service/client/src/components/Dashboard/RecentlyViewed/styled.tsx
+++ b/private-templates-service/client/src/components/Dashboard/RecentlyViewed/styled.tsx
@@ -31,8 +31,6 @@ export const RecentlyViewedHeader = styled.div`
 
 export const RecentlyViewedContainer = styled(Card)`
   flex: 0 1 auto;
-  border: 1px solid ${COLORS.BORDER2};
-  border-radius: 5px;
   justify-content: flex-start;
   margin-top: 10px;
   padding-bottom: 0px;


### PR DESCRIPTION
Removed shadows from `Card` panel in template view page ([AB#34370](https://microsoftgarage.visualstudio.com/002806e2-ebaa-4672-9d2e-5fe5d29154ef/_workitems/edit/34370)). Since `RecentlyViewed` component on Dashboard reuses the `Card` panel from template view page, shadows on from Dashboard are also gone ([AB#34169](https://microsoftgarage.visualstudio.com/002806e2-ebaa-4672-9d2e-5fe5d29154ef/_workitems/edit/34169)).

#Screenshots
## Template View Page (`TemplateInfo` component)
### Before
![image](https://user-images.githubusercontent.com/13890126/78080932-2604e400-7364-11ea-9f78-f0af67a8d5ab.png)

### After
![image](https://user-images.githubusercontent.com/13890126/78080970-35842d00-7364-11ea-8e23-2e630cc81eeb.png)

## Dashboard (`RecentlyViewed` component)
### Before
![image](https://user-images.githubusercontent.com/13890126/78080872-0372cb00-7364-11ea-9408-9b05edda4f8e.png)

### After
![image](https://user-images.githubusercontent.com/13890126/78081006-5187ce80-7364-11ea-9da2-c531f40d9c45.png)
