### PR TITLE
Make version modal scrollable

### DIFF
--- a/private-templates-service/client/src/components/Common/VersionModal/VersionModal.tsx
+++ b/private-templates-service/client/src/components/Common/VersionModal/VersionModal.tsx
@@ -28,7 +28,8 @@ import {
   VersionWrapper,
   DateWrapper,
   StatusWrapper,
-  CheckboxWrapper
+  CheckboxWrapper, 
+  VersionContainer
 } from './styled';
 
 import {
@@ -44,6 +45,7 @@ import { getDateString } from '../../../utils/versionUtils';
 import { capitalizeString } from "../../../utils/stringUtils";
 import ModalHOC from '../../../utils/ModalHOC';
 import { closeModal } from '../../../store/page/actions';
+import { Scroller } from '../../../utils/Scroller';
 
 interface Props {
   template: Template;
@@ -71,8 +73,10 @@ interface State {
 }
 
 class VersionModal extends React.Component<Props, State> {
+  scroller: Scroller;
   constructor(props: Props) {
     super(props);
+    this.scroller = new Scroller();
     this.state = { versionList: this.props.template.instances ? new Array(this.props.template.instances.length) : [] }
   }
 
@@ -129,6 +133,7 @@ class VersionModal extends React.Component<Props, State> {
                 <CardHeaderText>{`${this.state.versionList.filter(function (s) { return s; }).length} Selected`}</CardHeaderText>
               </CardHeaderRow>
               <CardBody>
+                <VersionContainer onWheel={this.scroller.verticalScroll}>
                 {this.props.template.instances && this.props.template.instances.map((instance: TemplateInstance, index: number) => (
                   <VersionCardRow>
                     <VersionWrapper>
@@ -147,6 +152,7 @@ class VersionModal extends React.Component<Props, State> {
                       }} /></CheckboxWrapper>
                   </VersionCardRow>
                 ))}
+                </VersionContainer>
               </CardBody>
             </Card>
           </CenterPanelWrapper>

--- a/private-templates-service/client/src/components/Common/VersionModal/styled.tsx
+++ b/private-templates-service/client/src/components/Common/VersionModal/styled.tsx
@@ -22,6 +22,7 @@ export const Modal = styled.div`
   background-color: ${COLORS.WHITE};
   width: 50%;
   padding: 48px;
+  overflow-y: hidden;
 `;
 
 export const Header = styled.div`
@@ -42,6 +43,7 @@ export const DescriptionAccent = styled.span`
 export const CenterPanelWrapper = styled.div`
   display: flex;
   margin-bottom: 24px;
+  overflow-y: hidden;
 `;
 
 export const BottomRow = styled.div`
@@ -72,6 +74,7 @@ export const Card = styled.div`
   border: 1px solid ${COLORS.BORDER};
   padding: 8px 0px 16px;
   margin-bottom: 24px;
+  overflow-y: hidden;
 `;
 
 export const CardHeaderRow = styled.div`
@@ -95,6 +98,7 @@ export const CardBody = styled.div`
   font-size: 0.875rem ;
   font-weight: 400;
   padding-top: 8px;
+  overflow-y: hidden;
 `;
 
 export const DateWrapper = styled.div`
@@ -123,7 +127,7 @@ export const CheckboxWrapper = styled.div`
 export const VersionContainer = styled.div`
 scroll-behavior: smooth;
 width: 100%;
-height: 200px;
+max-height: 200px;
 display: flex;
 flex-direction: column;
 flex-wrap: nowrap;

--- a/private-templates-service/client/src/components/Common/VersionModal/styled.tsx
+++ b/private-templates-service/client/src/components/Common/VersionModal/styled.tsx
@@ -120,3 +120,15 @@ export const CheckboxWrapper = styled.div`
   align-items: center;
   flex-basis: 15%;
 `
+export const VersionContainer = styled.div`
+scroll-behavior: smooth;
+width: 100%;
+height: 200px;
+display: flex;
+flex-direction: column;
+flex-wrap: nowrap;
+justify-content: flex-start;
+overflow-x: hidden;
+overflow-y: auto;
+-webkit-overflow-scrolling: touch;
+`;

--- a/private-templates-service/client/src/components/Dashboard/PreviewModal/TemplateInfo/VersionCard/VersionCard.tsx
+++ b/private-templates-service/client/src/components/Dashboard/PreviewModal/TemplateInfo/VersionCard/VersionCard.tsx
@@ -16,13 +16,13 @@ import {
   StatusWrapper,
   VersionIcon,
   VersionWrapper, 
-  InfoVersionContainer
+  InfoVersionContainer, 
+  VersionOuterCard, 
+  VersionCardBody
 } from './styled'
 
 import {
-  Card,
   CardHeader,
-  CardBody,
   StatusIndicator,
   Status
 } from './../styled';
@@ -66,7 +66,7 @@ class VersionCard extends React.Component<Props> {
 
   render() {
     return (
-      <Card key="Recent Releases" style={{ flex: '1 0 auto' }}>
+      <VersionOuterCard key="Recent Releases" style={{ flex: '1 0 auto' }}>
         <CardHeader>
           <VersionCardHeader>
             <CardTitle>Recent Releases</CardTitle>
@@ -75,7 +75,7 @@ class VersionCard extends React.Component<Props> {
             </CardManageButton>
           </VersionCardHeader>
         </CardHeader>
-        <CardBody>
+        <VersionCardBody>
           <VersionCardRow>
             <VersionCardRowTitle style={{ flexBasis: `15%` }}>Version</VersionCardRowTitle>
             <VersionCardRowTitle style={{ flexBasis: `25%` }}>Updated</VersionCardRowTitle>
@@ -96,9 +96,9 @@ class VersionCard extends React.Component<Props> {
             </VersionCardRow>
           ))}
           </InfoVersionContainer>
-        </CardBody>
+        </VersionCardBody>
         {this.props.modalState === ModalState.Version && <VersionModal template={this.props.template} />}
-      </Card>
+      </VersionOuterCard>
     );
   }
 }

--- a/private-templates-service/client/src/components/Dashboard/PreviewModal/TemplateInfo/VersionCard/VersionCard.tsx
+++ b/private-templates-service/client/src/components/Dashboard/PreviewModal/TemplateInfo/VersionCard/VersionCard.tsx
@@ -15,7 +15,8 @@ import {
   VersionCardRow,
   StatusWrapper,
   VersionIcon,
-  VersionWrapper
+  VersionWrapper, 
+  InfoVersionContainer
 } from './styled'
 
 import {
@@ -33,6 +34,7 @@ import { openModal } from '../../../../../store/page/actions';
 import VersionModal from '../../../../Common/VersionModal';
 import { MANAGE } from '../../../../../assets/strings';
 import { RootState } from '../../../../../store/rootReducer';
+import { Scroller } from "../../../../../utils/Scroller";
 
 interface Props {
   template: Template;
@@ -56,6 +58,12 @@ const mapDispatchToProps = (dispatch: any) => {
 };
 
 class VersionCard extends React.Component<Props> {
+  scroller: Scroller;
+  constructor(props: Props) {
+    super(props);
+    this.scroller = new Scroller();
+  }
+
   render() {
     return (
       <Card key="Recent Releases" style={{ flex: '1 0 auto' }}>
@@ -73,6 +81,7 @@ class VersionCard extends React.Component<Props> {
             <VersionCardRowTitle style={{ flexBasis: `25%` }}>Updated</VersionCardRowTitle>
             <VersionCardRowTitle style={{ flexBasis: `20%` }}>Status</VersionCardRowTitle>
           </VersionCardRow>
+          <InfoVersionContainer onWheel={this.scroller.verticalScroll}>
           {this.props.template.instances && this.props.template.instances.map((instance: TemplateInstance, index: number) => (
             <VersionCardRow key={index}>
               <VersionWrapper>
@@ -86,6 +95,7 @@ class VersionCard extends React.Component<Props> {
               </StatusWrapper>
             </VersionCardRow>
           ))}
+          </InfoVersionContainer>
         </CardBody>
         {this.props.modalState === ModalState.Version && <VersionModal template={this.props.template} />}
       </Card>

--- a/private-templates-service/client/src/components/Dashboard/PreviewModal/TemplateInfo/VersionCard/styled.tsx
+++ b/private-templates-service/client/src/components/Dashboard/PreviewModal/TemplateInfo/VersionCard/styled.tsx
@@ -5,6 +5,18 @@ import {
   VersionContainer
 } from '../../../../Common/VersionModal/styled';
 
+import {
+  Card,
+  CardBody
+} from './../styled';
+
+export const VersionOuterCard = styled(Card)`
+  overflow-y: hidden;
+`
+export const VersionCardBody = styled(CardBody)`
+  overflow-y: hidden;
+`
+
 export const CardManageButton = styled(ActionButton)`
   color: ${COLORS.GREY3};
   font-weight: 500;
@@ -73,5 +85,5 @@ export const VersionWrapper = styled.div`
 `
 
 export const InfoVersionContainer = styled(VersionContainer)`
-  height: 150px;
+  max-height: 150px;
 `

--- a/private-templates-service/client/src/components/Dashboard/PreviewModal/TemplateInfo/VersionCard/styled.tsx
+++ b/private-templates-service/client/src/components/Dashboard/PreviewModal/TemplateInfo/VersionCard/styled.tsx
@@ -1,6 +1,9 @@
 import styled from 'styled-components';
 import { COLORS } from '../../../../../globalStyles';
 import { ActionButton, Icon } from 'office-ui-fabric-react';
+import {
+  VersionContainer
+} from '../../../../Common/VersionModal/styled';
 
 export const CardManageButton = styled(ActionButton)`
   color: ${COLORS.GREY3};
@@ -67,4 +70,8 @@ export const VersionWrapper = styled.div`
   font-weight: 600;
   align-items: center;
   flex-basis: 15%;
+`
+
+export const InfoVersionContainer = styled(VersionContainer)`
+  height: 150px;
 `

--- a/private-templates-service/client/src/utils/Scroller.tsx
+++ b/private-templates-service/client/src/utils/Scroller.tsx
@@ -1,0 +1,17 @@
+
+export class Scroller {
+  timeStamp: number;
+  constructor() {
+      this.timeStamp = 0;
+  }
+  // TODO: decide which scroll feels more natural
+  verticalScroll = (e: React.WheelEvent) => {
+      e.preventDefault();
+      let item = e.currentTarget;
+      if (e.timeStamp - this.timeStamp < 1000) {
+          return;
+      }
+      this.timeStamp = e.timeStamp;
+      item.scrollTop += 10 * e.deltaY;
+  }
+}


### PR DESCRIPTION
Ticket: [TICKET-34327](https://microsoftgarage.visualstudio.com/Intern%20GitHub/_sprints/taskboard/Adaptive%20Cards/Intern%20GitHub/Y20-VW/11?workitem=34327)

This PR makes the version lists scrollable when there are many template versions. 

It also contains a verticalScroll function for a custom Scroller class, [Seva's all templates branch](https://github.com/microsoft/adaptivecards-templates/blob/users/vsevolod/all-templates-page/private-templates-service/client/src/utils/AllCardsUtil/AllCardsUtil.ts) will also have a similar class with horizontalScroll. These changes will be combined to single Scroller class in a future PR/when the later branch is merged to dev. 

![smallscroll](https://user-images.githubusercontent.com/31353754/78173452-a4b55c00-740c-11ea-8c59-cd51c7e0b1ee.jpg)

![bigscroll](https://user-images.githubusercontent.com/31353754/78161975-12588c80-73fb-11ea-97df-ec1bfb9c7c38.jpg)
