### PR TITLE
Remove extra slash in Shareable URL on Dev/Stage

### DIFF
--- a/private-templates-service/client/src/components/Common/ShareModal/ShareModal.tsx
+++ b/private-templates-service/client/src/components/Common/ShareModal/ShareModal.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { Template } from 'adaptive-templating-service-typescript-node';
+import { getShareURL, getFullShareURL } from '../../../utils/TemplateUtil/TemplateUtil';
 
 import Config from '../../../Config';
 import ShareModalForm from './ShareModalForm';
@@ -25,7 +26,6 @@ import {
   CopyLinkButton
 } from './styled';
 import * as STRINGS from '../../../assets/strings';
-
 
 interface ShareModalProps {
   template: Template;
@@ -55,8 +55,8 @@ class ShareModal extends React.Component<ShareModalProps> {
               <LinkRow>
                 <TextFieldContainer>
                   <TextField readOnly={true}
-                    prefix={Config.redirectUri}
-                    defaultValue={getShareURL(this.props)}
+                    prefix={Config.redirectUri.slice(-1) === "/" ? Config.redirectUri.slice(0, Config.redirectUri.length - 1) : Config.redirectUri}
+                    defaultValue={getShareURL(this.props.template.id, this.props.templateVersion)}
                     width={100} />
                 </TextFieldContainer>
                 <CopyLinkButton iconProps={{ iconName: 'Copy' }} onClick={() => { onCopyURL(this.props) }}>
@@ -64,27 +64,21 @@ class ShareModal extends React.Component<ShareModalProps> {
                 </CopyLinkButton>
               </LinkRow>
             </ShareLinkPanel>
-            <ShareModalForm shareURL={Config.redirectUri + getShareURL(this.props)} templateVersion={this.props.templateVersion} />
+            <ShareModalForm shareURL={getFullShareURL(this.props.template.id, this.props.templateVersion)} templateVersion={this.props.templateVersion} />
           </CenterPanelWrapper>
         </Modal>
-
       </BackDrop>
-
     );
   }
 }
 
 function onCopyURL(props: ShareModalProps) {
   let copyCode = document.createElement('textarea');
-  copyCode.innerText = Config.redirectUri + getShareURL(props);
+  copyCode.innerText = getFullShareURL(props.template.id, props.templateVersion);
   document.body.appendChild(copyCode);
   copyCode.select();
   document.execCommand('copy');
   copyCode.remove();
-}
-
-function getShareURL(props: ShareModalProps): string {
-  return "/preview/" + props.template.id + "/" + props.templateVersion;
 }
 
 function getShareModalDescription(template: Template, templateVersion: string): string {

--- a/private-templates-service/client/src/utils/TemplateUtil/TemplateUtil.ts
+++ b/private-templates-service/client/src/utils/TemplateUtil/TemplateUtil.ts
@@ -1,5 +1,6 @@
 import { Template, PostedTemplate, TemplateApi } from 'adaptive-templating-service-typescript-node';
 import { RootState } from "../../store/rootReducer"
+import Config from '../../Config';
 
 export function getLatestVersion(template?: Template): string {
   if (template && template.instances && template.instances[0] && template.instances[0].version) {
@@ -38,4 +39,12 @@ export function populateTemplate(getState: () => RootState): PostedTemplate {
 
   newTemplate.version = version;
   return newTemplate;
+}
+
+export function getShareURL(templateID?: string, templateVersion?: string): string {
+  return "/preview/" + templateID + "/" + templateVersion;
+}
+
+export function getFullShareURL(templateID?: string, templateVersion?: string): string {
+  return (Config.redirectUri + getShareURL(templateID, templateVersion)).replace("//", "/");
 }


### PR DESCRIPTION
[AB#34088](https://microsoftgarage.visualstudio.com/002806e2-ebaa-4672-9d2e-5fe5d29154ef/_workitems/edit/34088)

Removing the extra slash in shareable URL when displaying URL on dev or stage.

Did this by extracting the url builder function to the `TemplateUtil.tsx` file as I anticipate using it in other places. Modified this function so that it parses the URL and replaces `"//"` with `"/"`.

***I will only know if this worked if we push this to dev, but I'm fairly confident.***