### PR TITLE
 making the logo clickable ( sends user back to dashboard )

### DIFF
--- a/private-templates-service/client/src/components/SideBar/SideBar.tsx
+++ b/private-templates-service/client/src/components/SideBar/SideBar.tsx
@@ -11,6 +11,7 @@ import { COLORS } from "../../globalStyles";
 import UserAvatar from "./UserAvatar";
 import mainLogo from "../../assets/adaptive-cards-100-logo.png";
 import * as STRINGS from "../../assets/strings";
+import KeyCode from '../../globalKeyCodes'
 
 // CSS
 import {
@@ -162,10 +163,20 @@ const SideBar = (props: Props) => {
     history.push(element.url);
   };
 
+  const onLogoClick = () => {
+    history.push("/");
+  }
+  
+  const onKeyDown = (e:React.KeyboardEvent) => {
+    if(e.keyCode === KeyCode.ENTER){
+      history.push("/");
+    }
+  } 
+
   return (
     <OuterSideBarWrapper>
       <MainItems>
-        <LogoWrapper>
+        <LogoWrapper onClick={onLogoClick} tabIndex={props.modalState? -1 : 0} onKeyDown={onKeyDown}>
           <Logo aria-label={STRINGS.LOGO_DESCRIPTION} src={mainLogo} />
           <LogoTextWrapper>
             <LogoTextHeader>Adaptive Cards</LogoTextHeader>

--- a/private-templates-service/client/src/components/SideBar/styled.tsx
+++ b/private-templates-service/client/src/components/SideBar/styled.tsx
@@ -33,6 +33,7 @@ export const LogoWrapper = styled.div`
   align-items: center;
   margin-top: 20px;
   padding-right: 48px;
+  cursor: pointer;
 `;
 
 export const Logo = styled.img`


### PR DESCRIPTION
[AB#34254](https://microsoftgarage.visualstudio.com/002806e2-ebaa-4672-9d2e-5fe5d29154ef/_workitems/edit/34254) 

Overview of this change:
 - Added functionality that allowed the user to click the logo to return to the homepage.

Snapshots: 

Before:
![image](https://user-images.githubusercontent.com/17441040/78293072-dd246b00-74dc-11ea-80bb-3a6fc886e2cc.png)


After: 
![image](https://user-images.githubusercontent.com/17441040/78293017-c7af4100-74dc-11ea-87f5-a9efa99e4398.png)
