### PR TITLE
Add CosmosDB to deploy to azure button

### DIFF
--- a/private-templates-service/azuredeploy.json
+++ b/private-templates-service/azuredeploy.json
@@ -34,7 +34,7 @@
               "Yes",
               "No"
           ]
-      },
+      }
   },
   "variables": {
       "linuxFxVersion": "DOCKER|acmsregistry.azurecr.io/acmsimage",
@@ -64,7 +64,7 @@
           "location": "[parameters('location')]",
           "kind": "app,linux,container",
           "properties": {
-            "serverFarmId":"[resourceId('Microsoft.Web/serverfarms', variables('appServicePlanName'))]",
+            "serverFarmId":"[resourceId('Microsoft.Web/serverfarms', variables('appServicePlanName'))]"
           }, 
           "dependsOn": [
              "[resourceId('Microsoft.Web/serverfarms', variables('appServicePlanName'))]"
@@ -75,7 +75,7 @@
               "name": "appsettings",
               "type": "config",
               "dependsOn": [
-                "[concat('Microsoft.Web/Sites/', parameters('sites_adaptivecms_name'))]",
+                "[concat('Microsoft.Web/Sites/', parameters('sites_adaptivecms_name'))]"
               ],
               "properties": {
                 "ACMS_DB_CONNECTION": "[if(not(equals(parameters('mongodb_connection_string'), 'none')), listConnectionStrings(resourceId('Microsoft.DocumentDB/databaseAccounts', variables('cosmos_database_name')), '2015-04-08').connectionStrings[0].connectionString, parameters('mongodb_connection_string'))]",
@@ -85,7 +85,7 @@
                 "DOCKER_REGISTRY_SERVER_URL": "[parameters('docker_registry_server_uri')]",
                 "DOCKER_REGISTRY_SERVER_USERNAME": "[parameters('docker_registry_server_username')]",
                 "DOCKER_REGISTRY_SERVER_PASSWORD": "[parameters('docker_registry_server_password')]",
-                "ACMS_APP_INSIGHTS_INSTRUMENTATION_KEY": "[if(equals(parameters('telemetry_opt_in'), 'Yes'), variables('appInsightsInstrumentationKey'), '')]",
+                "ACMS_APP_INSIGHTS_INSTRUMENTATION_KEY": "[if(equals(parameters('telemetry_opt_in'), 'Yes'), variables('appInsightsInstrumentationKey'), '')]"
               }
             }
           ]

--- a/private-templates-service/azuredeploy.json
+++ b/private-templates-service/azuredeploy.json
@@ -6,10 +6,6 @@
           "defaultValue": "adaptivecmsdeploy",
           "type": "String"
       },
-      "mongodb_connection_string": {
-        "type": "String",
-        "defaultValue": "none"
-      },
       "app_id": {
         "type": "String"
       },
@@ -64,7 +60,7 @@
                 "[concat('Microsoft.Web/Sites/', parameters('sites_adaptivecms_name'))]"
               ],
               "properties": {
-                "ACMS_DB_CONNECTION": "[if(not(equals(parameters('mongodb_connection_string'), 'none')), listConnectionStrings(resourceId('Microsoft.DocumentDB/databaseAccounts', variables('cosmos_database_name')), '2015-04-08').connectionStrings[0].connectionString, parameters('mongodb_connection_string'))]",
+                "ACMS_DB_CONNECTION": "[listConnectionStrings(resourceId('Microsoft.DocumentDB/databaseAccounts', variables('cosmos_database_name')), '2015-04-08').connectionStrings[0].connectionString]",
                 "ACMS_REDIRECT_URI": "[concat('https://', parameters('sites_adaptivecms_name'), '.azurewebsites.net/')]",
                 "ACMS_APP_ID": "[parameters('app_id')]",
                 "WEBSITES_ENABLE_APP_SERVICE_STORAGE": "false",

--- a/private-templates-service/azuredeploy.json
+++ b/private-templates-service/azuredeploy.json
@@ -17,6 +17,9 @@
         "defaultValue": "West US",
         "type": "String"
       },
+      "server_farm_id": {
+        "type": "String"
+      },
       "docker_registry_server_uri": {
         "defaultValue": "https://acmsregistry.azurecr.io",
         "type": "String"
@@ -41,22 +44,8 @@
       "appInsightsInstrumentationKey": "931c613f-fdcb-40a9-bd39-314ce31bc5d6",
       "cosmos_database_name": "acms-cosmos",
       "databaseName": "acms",
-      "appServicePlanName": "acms-service-plan"
   },
   "resources": [
-      {
-        "type": "Microsoft.Web/serverfarms",
-        "apiVersion": "2018-02-01",
-        "name": "[variables('appServicePlanName')]",
-        "location": "[parameters('location')]",
-        "sku": {
-          "name": "F1"
-        },
-        "kind": "linux",
-        "properties":{
-          "reserved":true
-        }
-      },
       {
           "type": "Microsoft.Web/sites",
           "apiVersion": "2018-11-01",
@@ -64,11 +53,8 @@
           "location": "[parameters('location')]",
           "kind": "app,linux,container",
           "properties": {
-            "serverFarmId":"[resourceId('Microsoft.Web/serverfarms', variables('appServicePlanName'))]"
-          }, 
-          "dependsOn": [
-             "[resourceId('Microsoft.Web/serverfarms', variables('appServicePlanName'))]"
-          ],
+            "serverFarmId": "[parameters('server_farm_id')]"
+          },
           "resources": [   
             {
               "apiVersion": "2015-08-01",

--- a/private-templates-service/azuredeploy.json
+++ b/private-templates-service/azuredeploy.json
@@ -7,7 +7,8 @@
           "type": "String"
       },
       "mongodb_connection_string": {
-        "type": "String"
+        "type": "String",
+        "defaultValue": "none"
       },
       "app_id": {
         "type": "String"
@@ -41,6 +42,8 @@
   "variables": {
       "linuxFxVersion": "DOCKER|acmsregistry.azurecr.io/acmsimage",
       "appInsightsInstrumentationKey": "931c613f-fdcb-40a9-bd39-314ce31bc5d6",
+      "cosmos_database_name": "acms-cosmos",
+      "databaseName": "acms"
   },
   "resources": [
       {
@@ -61,7 +64,7 @@
                 "[concat('Microsoft.Web/Sites/', parameters('sites_adaptivecms_name'))]"
               ],
               "properties": {
-                "ACMS_DB_CONNECTION": "[parameters('mongodb_connection_string')]",
+                "ACMS_DB_CONNECTION": "[if(not(equals(parameters('mongodb_connection_string'), 'none')), listConnectionStrings(resourceId('Microsoft.DocumentDB/databaseAccounts', variables('cosmos_database_name')), '2015-04-08').connectionStrings[0].connectionString, parameters('mongodb_connection_string'))]",
                 "ACMS_REDIRECT_URI": "[concat('https://', parameters('sites_adaptivecms_name'), '.azurewebsites.net/')]",
                 "ACMS_APP_ID": "[parameters('app_id')]",
                 "WEBSITES_ENABLE_APP_SERVICE_STORAGE": "false",
@@ -141,6 +144,51 @@
               "ftpsState": "AllAllowed",
               "reservedInstanceCount": 0
           }
+      },
+      {
+        "type": "Microsoft.DocumentDB/databaseAccounts",
+        "name": "[variables('cosmos_database_name')]",
+        "apiVersion": "2019-08-01",
+        "location": "[parameters('location')]",
+        "kind": "MongoDB",
+        "properties": {
+          "consistencyPolicy": {
+              "defaultConsistencyLevel": "Session",
+              "maxIntervalInSeconds": 5,
+              "maxStalenessPrefix": 100
+          },
+          "locations": [
+              {
+                  "locationName":  "[parameters('location')]",
+                  "provisioningState": "Succeeded",
+                  "failoverPriority": 0,
+                  "isZoneRedundant": false
+              }
+          ],
+          "capabilities": [
+              {
+                  "name": "EnableMongo"
+              }
+          ],
+          "databaseAccountOfferType": "Standard",
+          "enableAutomaticFailover": false,
+          "enableMultipleWriteLocations": false,
+          "isVirtualNetworkFilterEnabled": false,
+          "virtualNetworkRules": [],
+          "disableKeyBasedMetadataWriteAccess": false
+        }
+      },
+      {
+        "type": "Microsoft.DocumentDB/databaseAccounts/mongodbDatabases",
+        "name": "[concat(variables('cosmos_database_name'), '/', variables('databaseName'))]",
+        "apiVersion": "2019-08-01",
+        "dependsOn": [ "[resourceId('Microsoft.DocumentDB/databaseAccounts/', variables('cosmos_database_name'))]" ],
+        "properties":{
+          "resource":{
+            "id": "[variables('databaseName')]"
+          },
+          "options": { "throughput": "400" }
+        }
       }
   ]
 } 

--- a/private-templates-service/azuredeploy.json
+++ b/private-templates-service/azuredeploy.json
@@ -17,9 +17,6 @@
         "defaultValue": "West US",
         "type": "String"
       },
-      "server_farm_id": {
-        "type": "String"
-      },
       "docker_registry_server_uri": {
         "defaultValue": "https://acmsregistry.azurecr.io",
         "type": "String"
@@ -43,9 +40,23 @@
       "linuxFxVersion": "DOCKER|acmsregistry.azurecr.io/acmsimage",
       "appInsightsInstrumentationKey": "931c613f-fdcb-40a9-bd39-314ce31bc5d6",
       "cosmos_database_name": "acms-cosmos",
-      "databaseName": "acms"
+      "databaseName": "acms",
+      "appServicePlanName": "acms-service-plan"
   },
   "resources": [
+      {
+        "type": "Microsoft.Web/serverfarms",
+        "apiVersion": "2018-02-01",
+        "name": "[variables('appServicePlanName')]",
+        "location": "[parameters('location')]",
+        "sku": {
+          "name": "F1"
+        },
+        "kind": "linux",
+        "properties":{
+          "reserved":true
+        }
+      },
       {
           "type": "Microsoft.Web/sites",
           "apiVersion": "2018-11-01",
@@ -53,15 +64,18 @@
           "location": "[parameters('location')]",
           "kind": "app,linux,container",
           "properties": {
-            "serverFarmId": "[parameters('server_farm_id')]",
+            "serverFarmId":"[resourceId('Microsoft.Web/serverfarms', variables('appServicePlanName'))]",
           }, 
+          "dependsOn": [
+             "[resourceId('Microsoft.Web/serverfarms', variables('appServicePlanName'))]"
+          ],
           "resources": [   
             {
               "apiVersion": "2015-08-01",
               "name": "appsettings",
               "type": "config",
               "dependsOn": [
-                "[concat('Microsoft.Web/Sites/', parameters('sites_adaptivecms_name'))]"
+                "[concat('Microsoft.Web/Sites/', parameters('sites_adaptivecms_name'))]",
               ],
               "properties": {
                 "ACMS_DB_CONNECTION": "[if(not(equals(parameters('mongodb_connection_string'), 'none')), listConnectionStrings(resourceId('Microsoft.DocumentDB/databaseAccounts', variables('cosmos_database_name')), '2015-04-08').connectionStrings[0].connectionString, parameters('mongodb_connection_string'))]",


### PR DESCRIPTION
Ticket: [TASK-34415](https://microsoftgarage.visualstudio.com/Intern%20GitHub/_sprints/taskboard/Adaptive%20Cards/Intern%20GitHub/Y20-VW/13?workitem=34415)

This PR enables the deploy to azure button to create a cosmosdb instance and database for the portal to connect to. 

Testing instructions can be found [here](https://github.com/microsoft/adaptivecards-templates/pull/211).