### PR TITLE
Make Tall cards scrollable on shared view page

### DIFF
--- a/private-templates-service/client/src/components/Shared/styled.tsx
+++ b/private-templates-service/client/src/components/Shared/styled.tsx
@@ -32,6 +32,7 @@ export const ACPanel = styled.div`
   flex-direction: column;
   align-items: center;
   justify-content: center;
+  overflow: auto;
 `;
 
 export const ACWrapper = styled.div`


### PR DESCRIPTION
[AB#34601](https://microsoftgarage.visualstudio.com/002806e2-ebaa-4672-9d2e-5fe5d29154ef/_workitems/edit/34601)

Added one line to make tall adaptive cards scrollable on the Shared page.

![image](https://user-images.githubusercontent.com/13890126/79495798-02839f80-7fda-11ea-9f9c-8b55189a4ca2.png)
