### PR TITLE
Fix favorite tag overflow and add h1&h2 headers 

### DIFF
--- a/private-templates-service/client/src/components/Common/Tags/styled.tsx
+++ b/private-templates-service/client/src/components/Common/Tags/styled.tsx
@@ -5,7 +5,9 @@ import { Icon } from 'office-ui-fabric-react';
 
 
 export const TagText = styled.div`
-  white-space: pre;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis; 
 `;
 
 export const TagCloseIcon = styled(Icon)`

--- a/private-templates-service/client/src/components/Common/TemplatesPage/TagList/styled.tsx
+++ b/private-templates-service/client/src/components/Common/TemplatesPage/TagList/styled.tsx
@@ -10,4 +10,5 @@ export const TagsContainer = styled.section`
   overflow-x: hidden;
   overflow-y: hidden;
   -webkit-overflow-scrolling: touch;
+  max-width: 100%;
 `;

--- a/private-templates-service/client/src/components/Dashboard/Dashboard.tsx
+++ b/private-templates-service/client/src/components/Dashboard/Dashboard.tsx
@@ -227,7 +227,7 @@ class Dashboard extends React.Component<Props> {
             </section>
           </DashboardContainer>
           <TagsContainer aria-label={FAVORITED_TAGS}>
-          <Title style={{ marginRight: "150px" }}>{FAVORITED_TAGS}</Title>
+          <Title>{FAVORITED_TAGS}</Title>
           <TagList tags={favoriteTags} 
                    allowEdit={false} 
                    onClick={this.tagOnClick} 

--- a/private-templates-service/client/src/components/Dashboard/PreviewModal/TemplateInfo/VersionCard/styled.tsx
+++ b/private-templates-service/client/src/components/Dashboard/PreviewModal/TemplateInfo/VersionCard/styled.tsx
@@ -21,7 +21,7 @@ export const CardManageButton = styled(ActionButton)`
   color: ${COLORS.GREY3};
 `
 
-export const CardTitle = styled.div`
+export const CardTitle = styled.h2`
   font-size: 1.375rem;
   font-family: ${FONTS.SEGOE_UI_SEMI_BOLD};
 `

--- a/private-templates-service/client/src/components/Dashboard/PreviewModal/TemplateInfo/styled.tsx
+++ b/private-templates-service/client/src/components/Dashboard/PreviewModal/TemplateInfo/styled.tsx
@@ -110,7 +110,7 @@ export const Card = styled.section`
   margin-bottom: 24px;
 `;
 
-export const CardHeader = styled.div`
+export const CardHeader = styled.h2`
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/private-templates-service/client/src/components/Dashboard/styled.tsx
+++ b/private-templates-service/client/src/components/Dashboard/styled.tsx
@@ -3,7 +3,7 @@ import { Spinner } from 'office-ui-fabric-react/lib/Spinner';
 
 import { COLORS, FONTS } from "../../globalStyles";
 
-export const Title = styled.h1`
+export const Title = styled.h2`
   padding-top: 15px;
   font-size: 1.5rem;
   font-family: ${FONTS.SEGOE_UI_SEMI_BOLD};

--- a/private-templates-service/client/src/components/NavBar/styled.tsx
+++ b/private-templates-service/client/src/components/NavBar/styled.tsx
@@ -46,7 +46,7 @@ export const StyledLogo = styled.img`
   }
 `;
 
-export const Styledh1 = styled.div`
+export const Styledh1 = styled.h1`
   letter-spacing: 0;
   opacity: 1;
   font-size: 1.875rem;
@@ -59,7 +59,7 @@ export const Styledh1 = styled.div`
   }
 `;
 
-export const Styledh2 = styled.div`
+export const Styledh2 = styled.h2`
   color: ${COLORS.WHITE};
   letter-spacing: 0;
   opacity: 1;


### PR DESCRIPTION
Tickets: [TASK-34465](https://microsoftgarage.visualstudio.com/Intern%20GitHub/_workitems/edit/34465), [BUG-34620](https://microsoftgarage.visualstudio.com/Intern%20GitHub/_workitems/edit/34620)

Favorite tags that overflow now cut off and show ellipses. 
![overflowtags](https://user-images.githubusercontent.com/31353754/79794881-e3ea1500-8307-11ea-8321-26271f75e4fe.jpg)

This PR also updates divs to h1 or h2 tags based on accessibility review. 
